### PR TITLE
FIX delete ID requirement from EntityDetailQuery

### DIFF
--- a/chat/core/src/main/java/com/tencent/supersonic/chat/query/rule/entity/EntityDetailQuery.java
+++ b/chat/core/src/main/java/com/tencent/supersonic/chat/query/rule/entity/EntityDetailQuery.java
@@ -14,8 +14,7 @@ public class EntityDetailQuery extends EntitySemanticQuery {
 
     public EntityDetailQuery() {
         super();
-        queryMatcher.addOption(DIMENSION, REQUIRED, AT_LEAST, 1)
-                .addOption(ID, REQUIRED, AT_LEAST, 1);
+        queryMatcher.addOption(DIMENSION, REQUIRED, AT_LEAST, 1);
     }
 
     @Override


### PR DESCRIPTION
When I submit a question that only contains entity and dimension like "8月17号渠道经销商简称"(“渠道” is the entity, "经销商简称" is the dimension)， the parser return fail. Therefore I debugged the parsers and found that EntityDetailQuery requires an "ID" in the issue. In my opinion, forcing entity detailed information queries to input 'ID' is unnecessary. When I delete the "ID" requirement, the parser runs well. Please help check the requirements of the rule and whether it is safe to do so.