### PR TITLE
(improvement) Print commands on console when running scripts

### DIFF
--- a/assembly/bin/supersonic-build.sh
+++ b/assembly/bin/supersonic-build.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -x
+
 # pip path
 pip_path=${PIP_PATH:-"/usr/local/bin/pip3"}
 

--- a/assembly/bin/supersonic-daemon.sh
+++ b/assembly/bin/supersonic-daemon.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -x
+
 python_path=${PYTHON_PATH:-"/usr/local/bin/python3"}
 readonly CHAT_APP_NAME="supersonic_chat"
 readonly SEMANTIC_APP_NAME="supersonic_semantic"


### PR DESCRIPTION
- Print commands on the console when running scripts, for better readability and traceability for each command

e.g. `sh assembly/bin/supersonic-build.sh`
![image](https://github.com/tencentmusic/supersonic/assets/1935105/eefcf32b-5fa5-49c8-aea5-c20f1c9e62f0)
