### PR TITLE
(improvement)(chat) SQL Corrector does special handling for COUNT_DIS…

### DIFF
--- a/chat/core/src/main/java/com/tencent/supersonic/chat/corrector/BaseSemanticCorrector.java
+++ b/chat/core/src/main/java/com/tencent/supersonic/chat/corrector/BaseSemanticCorrector.java
@@ -4,6 +4,7 @@ import com.tencent.supersonic.chat.api.component.SemanticCorrector;
 import com.tencent.supersonic.chat.api.pojo.SchemaElement;
 import com.tencent.supersonic.chat.api.pojo.SemanticCorrectInfo;
 import com.tencent.supersonic.chat.api.pojo.SemanticSchema;
+import com.tencent.supersonic.common.pojo.enums.AggOperatorEnum;
 import com.tencent.supersonic.common.pojo.enums.AggregateTypeEnum;
 import com.tencent.supersonic.common.util.ContextUtils;
 import com.tencent.supersonic.common.util.DateUtils;
@@ -74,6 +75,8 @@ public abstract class BaseSemanticCorrector implements SemanticCorrector {
         List<SchemaElement> metrics = getMetricElements(modelId);
 
         Map<String, String> metricToAggregate = metrics.stream()
+                //skip count_distinct metric
+                .filter(schemaElement -> !AggOperatorEnum.isCountDistinct(schemaElement.getDefaultAgg()))
                 .map(schemaElement -> {
                     if (Objects.isNull(schemaElement.getDefaultAgg())) {
                         schemaElement.setDefaultAgg(AggregateTypeEnum.SUM.name());

--- a/chat/core/src/main/java/com/tencent/supersonic/chat/corrector/GroupByCorrector.java
+++ b/chat/core/src/main/java/com/tencent/supersonic/chat/corrector/GroupByCorrector.java
@@ -2,6 +2,7 @@ package com.tencent.supersonic.chat.corrector;
 
 import com.tencent.supersonic.chat.api.pojo.SemanticCorrectInfo;
 import com.tencent.supersonic.chat.api.pojo.SemanticSchema;
+import com.tencent.supersonic.common.pojo.enums.AggOperatorEnum;
 import com.tencent.supersonic.common.util.ContextUtils;
 import com.tencent.supersonic.common.util.DateUtils;
 import com.tencent.supersonic.common.util.jsqlparser.SqlParserAddHelper;
@@ -60,9 +61,22 @@ public class GroupByCorrector extends BaseSemanticCorrector {
             return;
         }
 
+        final List<String> countDistinctList = semanticSchema.getMetrics(modelId).stream()
+                .filter(schemaElement -> AggOperatorEnum.isCountDistinct(schemaElement.getDefaultAgg()))
+                .flatMap(
+                        schemaElement -> {
+                            Set<String> elements = new HashSet<>();
+                            elements.add(schemaElement.getName());
+                            if (!CollectionUtils.isEmpty(schemaElement.getAlias())) {
+                                elements.addAll(schemaElement.getAlias());
+                            }
+                            return elements.stream();
+                        }
+                ).collect(Collectors.toList());
+
         List<String> aggregateFields = SqlParserSelectHelper.getAggregateFields(sql);
         Set<String> groupByFields = selectFields.stream()
-                .filter(field -> dimensions.contains(field))
+                .filter(field -> dimensions.contains(field) || countDistinctList.contains(field))
                 .filter(field -> {
                     if (!CollectionUtils.isEmpty(aggregateFields) && aggregateFields.contains(field)) {
                         return false;

--- a/common/src/main/java/com/tencent/supersonic/common/pojo/enums/AggOperatorEnum.java
+++ b/common/src/main/java/com/tencent/supersonic/common/pojo/enums/AggOperatorEnum.java
@@ -41,5 +41,16 @@ public enum AggOperatorEnum {
         return AggOperatorEnum.UNKNOWN;
     }
 
+    /**
+     * Determine if aggType is count_Distinct type
+     * COUNT_DISTINCT needs special handling when sql correction.
+     * Also when generating tableSql, count_distinct(field) needs to be parsed to count(distinct field).
+     * @param aggType aggType
+     * @return is count_Distinct type or not
+     */
+    public static boolean isCountDistinct(String aggType) {
+        return null != aggType && aggType.toUpperCase().equals(COUNT_DISTINCT.getOperator());
+    }
+
 
 }


### PR DESCRIPTION
1. count_distinct类型指标，SQL修正器统一忽略聚合函数填充处理（select、order by、group by、where）
2. 如果 select 字段中含有 count_distinct类型指标，则将该字段其设置为group by字段，以防ONLY_FULL_GROUP_BY模式下查询语法错误