### PR TITLE
(improvement)(chat) SemanticParseInfo removes elements whose model is empty

### DIFF
--- a/chat/api/src/main/java/com/tencent/supersonic/chat/api/pojo/SemanticParseInfo.java
+++ b/chat/api/src/main/java/com/tencent/supersonic/chat/api/pojo/SemanticParseInfo.java
@@ -88,10 +88,11 @@ public class SemanticParseInfo {
 
     private Map<Long, Integer> getModelElementCountMap() {
         Map<Long, Integer> elementCountMap = new HashMap<>();
-        elementMatches.forEach(element -> {
-            int count = elementCountMap.getOrDefault(element.getElement().getModel(), 0);
-            elementCountMap.put(element.getElement().getModel(), count + 1);
-        });
+        elementMatches.stream().filter(element -> element.getElement().getModel() != null)
+                .forEach(element -> {
+                    int count = elementCountMap.getOrDefault(element.getElement().getModel(), 0);
+                    elementCountMap.put(element.getElement().getModel(), count + 1);
+                });
         return elementCountMap;
     }
 

--- a/chat/core/src/main/java/com/tencent/supersonic/chat/processor/MetricCheckProcessor.java
+++ b/chat/core/src/main/java/com/tencent/supersonic/chat/processor/MetricCheckProcessor.java
@@ -79,7 +79,8 @@ public class MetricCheckProcessor implements ParseResultProcessor {
             }
         }
         for (String dimensionName : whereFields) {
-            if (TimeDimensionEnum.getNameList().contains(dimensionName)) {
+            if (TimeDimensionEnum.getNameList().contains(dimensionName)
+                    || TimeDimensionEnum.getChNameList().contains(dimensionName)) {
                 continue;
             }
             if (!checkInModelSchema(dimensionName, SchemaElementType.DIMENSION, semanticSchema)) {
@@ -90,7 +91,8 @@ public class MetricCheckProcessor implements ParseResultProcessor {
             }
         }
         for (String dimensionName : groupByFields) {
-            if (TimeDimensionEnum.getNameList().contains(dimensionName)) {
+            if (TimeDimensionEnum.getNameList().contains(dimensionName)
+                    || TimeDimensionEnum.getChNameList().contains(dimensionName)) {
                 continue;
             }
             if (!checkInModelSchema(dimensionName, SchemaElementType.DIMENSION, semanticSchema)) {

--- a/launchers/chat/src/main/resources/META-INF/spring.factories
+++ b/launchers/chat/src/main/resources/META-INF/spring.factories
@@ -44,5 +44,4 @@ com.tencent.supersonic.chat.postprocessor.PostProcessor=\
     com.tencent.supersonic.chat.postprocessor.RespBuildPostProcessor
 
 com.tencent.supersonic.chat.query.QueryResponder=\
-    com.tencent.supersonic.chat.query.EntityInfoQueryResponder, \
     com.tencent.supersonic.chat.query.SimilarMetricQueryResponder

--- a/launchers/standalone/src/test/resources/META-INF/spring.factories
+++ b/launchers/standalone/src/test/resources/META-INF/spring.factories
@@ -43,5 +43,4 @@ com.tencent.supersonic.chat.postprocessor.PostProcessor=\
 
 
 com.tencent.supersonic.chat.query.QueryResponder=\
-    com.tencent.supersonic.chat.query.EntityInfoQueryResponder, \
     com.tencent.supersonic.chat.query.SimilarMetricQueryResponder


### PR DESCRIPTION
1. MetricCheckProcessor compatible time dimension chName
2. SemanticParseInfo removes elements whose model is empty
3. Update spi in test profile


