### PR TITLE
(improvement)(chat) The history record only retains the query result of the first parse

### DIFF
--- a/chat/core/src/main/java/com/tencent/supersonic/chat/service/ChatService.java
+++ b/chat/core/src/main/java/com/tencent/supersonic/chat/service/ChatService.java
@@ -53,7 +53,7 @@ public interface ChatService {
 
     int updateQuery(ChatQueryDO chatQueryDO);
 
-    Boolean updateQuery(Long questionId, QueryResult queryResult, ChatContext chatCtx);
+    void updateQuery(Long questionId, int parseId, QueryResult queryResult, ChatContext chatCtx);
 
     ChatParseDO getParseInfo(Long questionId, int parseId);
 

--- a/chat/core/src/main/java/com/tencent/supersonic/chat/service/impl/ChatServiceImpl.java
+++ b/chat/core/src/main/java/com/tencent/supersonic/chat/service/impl/ChatServiceImpl.java
@@ -196,7 +196,11 @@ public class ChatServiceImpl implements ChatService {
     }
 
     @Override
-    public Boolean updateQuery(Long questionId, QueryResult queryResult, ChatContext chatCtx) {
+    public void updateQuery(Long questionId, int parseId, QueryResult queryResult, ChatContext chatCtx) {
+        //The history record only retains the query result of the first parse
+        if (parseId > 1) {
+            return;
+        }
         ChatQueryDO chatQueryDO = new ChatQueryDO();
         chatQueryDO.setQuestionId(questionId);
         chatQueryDO.setQueryResult(JsonUtil.toString(queryResult));
@@ -204,7 +208,6 @@ public class ChatServiceImpl implements ChatService {
         updateQuery(chatQueryDO);
         chatRepository.updateLastQuestion(chatCtx.getChatId().longValue(),
                 chatCtx.getQueryText(), getCurrentTime());
-        return true;
     }
 
     @Override

--- a/chat/core/src/main/java/com/tencent/supersonic/chat/service/impl/QueryServiceImpl.java
+++ b/chat/core/src/main/java/com/tencent/supersonic/chat/service/impl/QueryServiceImpl.java
@@ -209,7 +209,7 @@ public class QueryServiceImpl implements QueryService {
             for (ExecuteResultProcessor executeResultProcessor : executeProcessors) {
                 executeResultProcessor.process(queryResult, parseInfo, queryReq);
             }
-            chatService.updateQuery(queryReq.getQueryId(), queryResult, chatCtx);
+            chatService.updateQuery(queryReq.getQueryId(), queryReq.getParseId(), queryResult, chatCtx);
         } else {
             chatService.deleteChatQuery(queryReq.getQueryId());
         }


### PR DESCRIPTION
The history record only retains the query result of the first parse