### PR TITLE
(fix)(chat):queryByStruct use default metrics period

### DIFF
--- a/chat/core/src/main/java/com/tencent/supersonic/chat/core/utils/DictQueryHelper.java
+++ b/chat/core/src/main/java/com/tencent/supersonic/chat/core/utils/DictQueryHelper.java
@@ -175,6 +175,7 @@ public class DictQueryHelper {
         dateInfo.setDateMode(DateConf.DateMode.RECENT);
         log.debug("defaultMetric unit():{}", defaultMetricDesc.getUnit());
         dateInfo.setUnit(defaultMetricDesc.getUnit());
+        dateInfo.setPeriod(defaultMetricDesc.getPeriod());
         queryStructCmd.setDateInfo(dateInfo);
 
         queryStructCmd.setLimit(dimMaxLimit);


### PR DESCRIPTION
queryByStruct时，时间单位沿用defaultMetricDesc上的