### PR TITLE
(fix)(headless) Add hadoop-hdfs dependency in pom to avoid no fileSystem for scheme: hdfs

### DIFF
--- a/headless/core/pom.xml
+++ b/headless/core/pom.xml
@@ -102,11 +102,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
-<!--        <dependency>-->
-<!--            <groupId>com.hankcs</groupId>-->
-<!--            <artifactId>hanlp</artifactId>-->
-<!--            <version>${hanlp.version}</version>-->
-<!--        </dependency>-->
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-hdfs</artifactId>
+            <version>${hadoop.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>


### PR DESCRIPTION
 Add hadoop-hdfs dependency in pom to avoid no fileSystem for scheme: hdfs