### PR TITLE
(improvement)(headless) When creating a view, conflict detection is not performed when the front end provides an empty list of metric and dimensions.

### DIFF
--- a/headless/server/src/main/java/com/tencent/supersonic/headless/server/service/impl/ViewServiceImpl.java
+++ b/headless/server/src/main/java/com/tencent/supersonic/headless/server/service/impl/ViewServiceImpl.java
@@ -203,27 +203,30 @@ public class ViewServiceImpl
         List<Long> allDimensionIds = viewResp.getAllDimensions();
         List<Long> allMetricIds = viewResp.getAllMetrics();
         MetaFilter metaFilter = new MetaFilter();
-        metaFilter.setIds(allDimensionIds);
-        List<DimensionResp> dimensionResps = dimensionService.getDimensions(metaFilter);
-        metaFilter.setIds(allMetricIds);
-        List<MetricResp> metricResps = metricService.getMetrics(metaFilter);
+        if (!CollectionUtils.isEmpty(allDimensionIds)) {
+            metaFilter.setIds(allDimensionIds);
+            List<DimensionResp> dimensionResps = dimensionService.getDimensions(metaFilter);
+            List<String> duplicateDimensionNames = findDuplicates(dimensionResps, DimensionResp::getName);
+            List<String> duplicateDimensionBizNames = findDuplicates(dimensionResps, DimensionResp::getBizName);
+            if (!duplicateDimensionNames.isEmpty()) {
+                throw new InvalidArgumentException("存在相同的维度名: " + duplicateDimensionNames);
+            }
+            if (!duplicateDimensionBizNames.isEmpty()) {
+                throw new InvalidArgumentException("存在相同的维度英文名: " + duplicateDimensionBizNames);
+            }
+        }
+        if (!CollectionUtils.isEmpty(allMetricIds)) {
+            metaFilter.setIds(allMetricIds);
+            List<MetricResp> metricResps = metricService.getMetrics(metaFilter);
+            List<String> duplicateMetricNames = findDuplicates(metricResps, MetricResp::getName);
+            List<String> duplicateMetricBizNames = findDuplicates(metricResps, MetricResp::getBizName);
 
-        List<String> duplicateDimensionNames = findDuplicates(dimensionResps, DimensionResp::getName);
-        List<String> duplicateDimensionBizNames = findDuplicates(dimensionResps, DimensionResp::getBizName);
-
-        List<String> duplicateMetricNames = findDuplicates(metricResps, MetricResp::getName);
-        List<String> duplicateMetricBizNames = findDuplicates(metricResps, MetricResp::getBizName);
-        if (!duplicateDimensionNames.isEmpty()) {
-            throw new InvalidArgumentException("存在相同的维度名: " + duplicateDimensionNames);
-        }
-        if (!duplicateDimensionBizNames.isEmpty()) {
-            throw new InvalidArgumentException("存在相同的维度英文名: " + duplicateDimensionBizNames);
-        }
-        if (!duplicateMetricNames.isEmpty()) {
-            throw new InvalidArgumentException("存在相同的指标名: " + duplicateMetricNames);
-        }
-        if (!duplicateMetricBizNames.isEmpty()) {
-            throw new InvalidArgumentException("存在相同的指标英文名: " + duplicateMetricBizNames);
+            if (!duplicateMetricNames.isEmpty()) {
+                throw new InvalidArgumentException("存在相同的指标名: " + duplicateMetricNames);
+            }
+            if (!duplicateMetricBizNames.isEmpty()) {
+                throw new InvalidArgumentException("存在相同的指标英文名: " + duplicateMetricBizNames);
+            }
         }
     }
 


### PR DESCRIPTION
When creating a view, conflict detection is not performed when the front end provides an empty list of metric and dimensions.