### PR TITLE
(improvement)(headless) When the drill-down dimension inherited from the model is removed from the model's settings, it will no longer be displayed in the drill-down dimension of the metric

### DIFF
--- a/headless/server/src/main/java/com/tencent/supersonic/headless/server/service/impl/MetricServiceImpl.java
+++ b/headless/server/src/main/java/com/tencent/supersonic/headless/server/service/impl/MetricServiceImpl.java
@@ -360,7 +360,12 @@ public class MetricServiceImpl implements MetricService {
         }
         if (metricResp.getRelateDimension() != null
                 && !CollectionUtils.isEmpty(metricResp.getRelateDimension().getDrillDownDimensions())) {
-            drillDownDimensions.addAll(metricResp.getRelateDimension().getDrillDownDimensions());
+            for (DrillDownDimension drillDownDimension : metricResp.getRelateDimension().getDrillDownDimensions()) {
+                if (drillDownDimension.isInheritedFromModel() && !drillDownDimension.isNecessary()) {
+                    continue;
+                }
+                drillDownDimensions.add(drillDownDimension);
+            }
         }
         ModelResp modelResp = modelService.getModel(metricResp.getModelId());
         if (modelResp.getDrillDownDimensions() == null) {


### PR DESCRIPTION
When the drill-down dimension inherited from the model is removed from the model's settings, it will no longer be displayed in the drill-down dimension of the metric