### PR TITLE
fix queryTagMarketPage when tagObject is unused

### DIFF
--- a/headless/server/src/main/java/com/tencent/supersonic/headless/server/service/impl/TagMetaServiceImpl.java
+++ b/headless/server/src/main/java/com/tencent/supersonic/headless/server/service/impl/TagMetaServiceImpl.java
@@ -161,6 +161,9 @@ public class TagMetaServiceImpl implements TagMetaService {
                     .filter(modelResp -> tagMarketPageReq.getTagObjectId().equals(modelResp.getTagObjectId()))
                     .collect(Collectors.toList());
         }
+        if (CollectionUtils.isEmpty(modelRespList)) {
+            return new PageInfo<TagResp>();
+        }
         List<Long> modelIds = modelRespList.stream().map(model -> model.getId()).collect(Collectors.toList());
 
         TagFilter tagFilter = new TagFilter();

--- a/headless/server/src/main/java/com/tencent/supersonic/headless/server/service/impl/TagQueryServiceImpl.java
+++ b/headless/server/src/main/java/com/tencent/supersonic/headless/server/service/impl/TagQueryServiceImpl.java
@@ -76,8 +76,8 @@ public class TagQueryServiceImpl implements TagQueryService {
     }
 
     private void checkTag(TagResp tag) throws Exception {
-        if (Objects.nonNull(tag) && TagDefineType.METRIC.equals(tag.getTagDefineType())) {
-            throw new Exception("do not support value distribution query for tag: " + tag.getBizName());
+        if (Objects.nonNull(tag) && TagDefineType.METRIC.name().equalsIgnoreCase(tag.getTagDefineType())) {
+            throw new Exception("do not support value distribution query for tag (from metric): " + tag.getBizName());
         }
     }
 


### PR DESCRIPTION
fix queryTagMarketPage when tagObject is unused