### PR TITLE
#The agentId type conversion error is fixed

### DIFF
--- a/chat/server/src/main/java/com/tencent/supersonic/chat/server/util/SimilarQueryManager.java
+++ b/chat/server/src/main/java/com/tencent/supersonic/chat/server/util/SimilarQueryManager.java
@@ -56,7 +56,7 @@ public class SimilarQueryManager {
         String queryText = similarQueryReq.getQueryText();
         try {
             Map<String, Object> metaData = new HashMap<>();
-            metaData.put("agentId", similarQueryReq.getAgentId());
+            metaData.put("agentId", String.valueOf(similarQueryReq.getAgentId()));
             TextSegment textSegment = TextSegment.from(queryText, new Metadata(metaData));
             TextSegmentConvert.addQueryId(textSegment, String.valueOf(similarQueryReq.getQueryId()));
 

--- a/chat/server/src/main/java/com/tencent/supersonic/chat/server/util/SimilarQueryManager.java
+++ b/chat/server/src/main/java/com/tencent/supersonic/chat/server/util/SimilarQueryManager.java
@@ -56,7 +56,7 @@ public class SimilarQueryManager {
         String queryText = similarQueryReq.getQueryText();
         try {
             Map<String, Object> metaData = new HashMap<>();
-            metaData.put("agentId", String.valueOf(similarQueryReq.getAgentId()));
+            metaData.put("agentId", similarQueryReq.getAgentId());
             TextSegment textSegment = TextSegment.from(queryText, new Metadata(metaData));
             TextSegmentConvert.addQueryId(textSegment, String.valueOf(similarQueryReq.getQueryId()));
 


### PR DESCRIPTION
Execute Enbedin Storey at startup. Silch method reports type conversion error exception, aligns Aktu Alvarho, and Compari Sovallo types