### PR TITLE
(fix)(pom) Specify the Gson version explicitly instead of relying on the Spring POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
         <flight-sql.version>15.0.2</flight-sql.version>
         <arrow-jdbc.version>15.0.2</arrow-jdbc.version>
         <flight-sql-jdbc-driver.version>15.0.2</flight-sql-jdbc-driver.version>
+        <gson.version>2.10.1</gson.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
## Description
Specify the Gson version explicitly instead of relying on the Spring POM