### PR TITLE
解决“智能填充”功能只能填充演示数据，不能对后续添加的数据集进行智能填充的问题

### DIFF
--- a/headless/server/src/main/java/com/tencent/supersonic/headless/server/web/service/impl/DimensionServiceImpl.java
+++ b/headless/server/src/main/java/com/tencent/supersonic/headless/server/web/service/impl/DimensionServiceImpl.java
@@ -370,7 +370,8 @@ public class DimensionServiceImpl extends ServiceImpl<DimensionDOMapper, Dimensi
     public List<DimValueMap> mockDimensionValueAlias(DimensionReq dimensionReq, User user) {
         ModelResp modelResp = modelService.getModel(dimensionReq.getModelId());
         ModelDetail modelDetail = modelResp.getModelDetail();
-        String sqlQuery = modelDetail.getSqlQuery();
+        String tableQuery = modelDetail.getTableQuery();
+        String sqlQuery = "SELECT * FROM " + tableQuery;
         DatabaseResp database = databaseService.getDatabase(modelResp.getDatabaseId());
 
         String sql = "select ai_talk." + dimensionReq.getBizName() + " from (" + sqlQuery


### PR DESCRIPTION
#修改前
代码下载下来，然后自己添加数据集之后再点击“智能填充”报错，大概原因是会获取到这样一个sql：select ai_talk.gender from () as ai_talk group by ai_talk.gender，因为这个sql括号里是空，所以智能填充功能无法生效。
翻了一下代码括号里面的sql是在这个地方set的：
![8c922222dcf86ad89e81d47d1d05266](https://github.com/tencentmusic/supersonic/assets/110003994/415433a6-fda0-47de-8924-d97bf5e8eef3)
但是set的这个地方只有演示数据存在，自己添加的数据集是没有的。
#修改后
对于自己添加的数据集可以正常使用”智能填充“功能。