### PR TITLE
fix existSegment bug which embedding search not has min-score,so that…

### DIFF
--- a/common/src/main/java/com/tencent/supersonic/common/service/impl/EmbeddingServiceImpl.java
+++ b/common/src/main/java/com/tencent/supersonic/common/service/impl/EmbeddingServiceImpl.java
@@ -3,6 +3,7 @@ package com.tencent.supersonic.common.service.impl;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.tencent.supersonic.common.service.EmbeddingService;
+import com.tencent.supersonic.common.util.ContextUtils;
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.embedding.EmbeddingModel;
@@ -81,11 +82,10 @@ public class EmbeddingServiceImpl implements EmbeddingService {
         Filter filter = createCombinedFilter(filterCondition);
 
         EmbeddingSearchRequest request = EmbeddingSearchRequest.builder()
-                .queryEmbedding(embedding).filter(filter).maxResults(1).build();
+                .queryEmbedding(embedding).filter(filter).minScore(1.0d).maxResults(1).build();
 
         EmbeddingSearchResult result = embeddingStore.search(request);
         List<EmbeddingMatch<TextSegment>> relevant = result.matches();
-
         boolean exists = CollectionUtils.isNotEmpty(relevant);
 
         cache.put(queryId, exists);
@@ -126,7 +126,6 @@ public class EmbeddingServiceImpl implements EmbeddingService {
             Filter filter = createCombinedFilter(filterCondition);
             EmbeddingSearchRequest request = EmbeddingSearchRequest.builder()
                     .queryEmbedding(embeddedText).filter(filter).maxResults(num).build();
-
             EmbeddingSearchResult result = embeddingStore.search(request);
             List<EmbeddingMatch<TextSegment>> relevant = result.matches();
 
@@ -154,7 +153,6 @@ public class EmbeddingServiceImpl implements EmbeddingService {
             retrieveQueryResult.setRetrieval(retrievals);
             results.add(retrieveQueryResult);
         }
-
         return results;
     }
 

--- a/common/src/main/java/com/tencent/supersonic/common/service/impl/EmbeddingServiceImpl.java
+++ b/common/src/main/java/com/tencent/supersonic/common/service/impl/EmbeddingServiceImpl.java
@@ -3,7 +3,6 @@ package com.tencent.supersonic.common.service.impl;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.tencent.supersonic.common.service.EmbeddingService;
-import com.tencent.supersonic.common.util.ContextUtils;
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.embedding.EmbeddingModel;
@@ -80,14 +79,12 @@ public class EmbeddingServiceImpl implements EmbeddingService {
         Map<String, String> filterCondition = new HashMap<>();
         filterCondition.put(TextSegmentConvert.QUERY_ID, queryId);
         Filter filter = createCombinedFilter(filterCondition);
-
         EmbeddingSearchRequest request = EmbeddingSearchRequest.builder()
                 .queryEmbedding(embedding).filter(filter).minScore(1.0d).maxResults(1).build();
 
         EmbeddingSearchResult result = embeddingStore.search(request);
         List<EmbeddingMatch<TextSegment>> relevant = result.matches();
         boolean exists = CollectionUtils.isNotEmpty(relevant);
-
         cache.put(queryId, exists);
         return exists;
     }
@@ -128,7 +125,6 @@ public class EmbeddingServiceImpl implements EmbeddingService {
                     .queryEmbedding(embeddedText).filter(filter).maxResults(num).build();
             EmbeddingSearchResult result = embeddingStore.search(request);
             List<EmbeddingMatch<TextSegment>> relevant = result.matches();
-
             RetrieveQueryResult retrieveQueryResult = new RetrieveQueryResult();
             retrieveQueryResult.setQuery(queryText);
             List<Retrieval> retrievals = new ArrayList<>();


### PR DESCRIPTION
… it will return true.

# Pull Req
<img width="616" alt="微信图片_20240716151520" src="https://github.com/user-attachments/assets/5ed82a6c-0673-4837-aae9-33de26865599">
<img width="491" alt="微信图片_20240716151528" src="https://github.com/user-attachments/assets/81b77435-fc07-41bf-afd1-6ab9651ac4db">
<img width="496" alt="微信图片_20240716151531" src="https://github.com/user-attachments/assets/057d718a-439d-43d3-9ed3-6f63e8e20423">
uest Template

## Description

修复add query 时候判断 文本段是否存在的bug，在使用 in memory 模式的embedding模型，特别是低维模型，总是返回true
因此需要加上minScore=1.0才能真正的判断文本段是否已经存在向量库中。

