### PR TITLE
[fix][headless]指定不限制数据集查询范围时时Detail类型也不再额外增加限制

### DIFF
--- a/headless/chat/src/main/java/com/tencent/supersonic/headless/chat/corrector/S2SqlDateHelper.java
+++ b/headless/chat/src/main/java/com/tencent/supersonic/headless/chat/corrector/S2SqlDateHelper.java
@@ -37,7 +37,7 @@ public class S2SqlDateHelper {
             return Pair.of(defaultDate, defaultDate);
         }
         TimeDefaultConfig defaultConfig = dataSetSchema.getMetricTypeTimeDefaultConfig();
-        if (QueryType.DETAIL.equals(queryType)) {
+        if (QueryType.DETAIL.equals(queryType) && defaultConfig.getUnit() >= 0) {
             defaultConfig = dataSetSchema.getTagTypeTimeDefaultConfig();
         }
         return getDefaultDate(defaultDate, defaultConfig);


### PR DESCRIPTION
对issue https://github.com/tencentmusic/supersonic/issues/1508 的跟进与修复
数据集查询时间-1（不额外增加时间限制）时：
修复前：
![image](https://github.com/user-attachments/assets/cd9473cf-d3e3-4ce7-9da6-e056c7442d9f)

修复后：
![image](https://github.com/user-attachments/assets/5ab58ed7-b131-4f61-b3e5-3b23bcee5796)
