### PR TITLE
(improvement)(headless) If no time partition is configured, the metric market does not support querying by time

### DIFF
--- a/headless/api/src/main/java/com/tencent/supersonic/headless/api/pojo/response/MetricResp.java
+++ b/headless/api/src/main/java/com/tencent/supersonic/headless/api/pojo/response/MetricResp.java
@@ -69,6 +69,8 @@ public class MetricResp extends SchemaItem {
 
     private String defaultAgg;
 
+    private boolean containsPartitionDimensions;
+
     public void setClassifications(String tag) {
         if (StringUtils.isBlank(tag)) {
             classifications = Lists.newArrayList();

--- a/headless/server/src/main/java/com/tencent/supersonic/headless/server/service/impl/MetricServiceImpl.java
+++ b/headless/server/src/main/java/com/tencent/supersonic/headless/server/service/impl/MetricServiceImpl.java
@@ -529,7 +529,7 @@ public class MetricServiceImpl extends ServiceImpl<MetricDOMapper, MetricDO>
         if (metricDO == null) {
             return null;
         }
-        ModelFilter modelFilter = new ModelFilter(false,
+        ModelFilter modelFilter = new ModelFilter(true,
                 Lists.newArrayList(metricDO.getModelId()));
         Map<Long, ModelResp> modelMap = modelService.getModelMap(modelFilter);
         List<CollectDO> collectList = collectService.getCollectionList(user.getName(), TypeEnums.METRIC);

--- a/headless/server/src/main/java/com/tencent/supersonic/headless/server/utils/MetricConverter.java
+++ b/headless/server/src/main/java/com/tencent/supersonic/headless/server/utils/MetricConverter.java
@@ -7,16 +7,18 @@ import com.tencent.supersonic.common.pojo.enums.PublishEnum;
 import com.tencent.supersonic.common.pojo.enums.StatusEnum;
 import com.tencent.supersonic.common.pojo.enums.TypeEnums;
 import com.tencent.supersonic.common.util.BeanMapper;
-import com.tencent.supersonic.headless.api.pojo.enums.MetricDefineType;
+import com.tencent.supersonic.headless.api.pojo.Dim;
 import com.tencent.supersonic.headless.api.pojo.MetricDefineByFieldParams;
 import com.tencent.supersonic.headless.api.pojo.MetricDefineByMeasureParams;
 import com.tencent.supersonic.headless.api.pojo.MetricDefineByMetricParams;
 import com.tencent.supersonic.headless.api.pojo.RelateDimension;
+import com.tencent.supersonic.headless.api.pojo.enums.MetricDefineType;
 import com.tencent.supersonic.headless.api.pojo.request.MetricReq;
+import com.tencent.supersonic.headless.api.pojo.response.DataSetResp;
 import com.tencent.supersonic.headless.api.pojo.response.MetricResp;
 import com.tencent.supersonic.headless.api.pojo.response.ModelResp;
-import com.tencent.supersonic.headless.api.pojo.response.DataSetResp;
 import com.tencent.supersonic.headless.server.persistence.dataobject.MetricDO;
+import org.apache.commons.collections.CollectionUtils;
 import org.springframework.beans.BeanUtils;
 
 import java.util.HashMap;
@@ -78,7 +80,12 @@ public class MetricConverter {
             metricResp.setModelName(modelResp.getName());
             metricResp.setModelBizName(modelResp.getBizName());
             metricResp.setDomainId(modelResp.getDomainId());
+            List<Dim> timeDims = modelResp.getTimeDimension();
+            if (CollectionUtils.isNotEmpty(timeDims)) {
+                metricResp.setContainsPartitionDimensions(true);
+            }
         }
+
         metricResp.setIsCollect(collect != null && collect.contains(metricDO.getId()));
         metricResp.setClassifications(metricDO.getClassifications());
         metricResp.setRelateDimension(JSONObject.parseObject(metricDO.getRelateDimensions(),


### PR DESCRIPTION

## Description
If no time partition is configured, the metric market does not support querying by time
