### PR TITLE
[fix][chat]修复对话丢失问题

### DIFF
--- a/chat/server/src/main/java/com/tencent/supersonic/chat/server/persistence/repository/impl/ChatQueryRepositoryImpl.java
+++ b/chat/server/src/main/java/com/tencent/supersonic/chat/server/persistence/repository/impl/ChatQueryRepositoryImpl.java
@@ -61,7 +61,8 @@ public class ChatQueryRepositoryImpl implements ChatQueryRepository {
         if (!CollectionUtils.isEmpty(pageQueryInfoReq.getIds())) {
             queryWrapper.lambda().in(ChatQueryDO::getQuestionId, pageQueryInfoReq.getIds());
         }
-
+        queryWrapper.lambda().isNotNull(ChatQueryDO::getQueryResult);
+        queryWrapper.lambda().ne(ChatQueryDO::getQueryResult, "");
         queryWrapper.lambda().orderByDesc(ChatQueryDO::getQuestionId);
 
         PageInfo<ChatQueryDO> pageInfo = PageHelper.startPage(pageQueryInfoReq.getCurrent(),
@@ -70,8 +71,9 @@ public class ChatQueryRepositoryImpl implements ChatQueryRepository {
 
         PageInfo<QueryResp> chatQueryVOPageInfo = PageUtils.pageInfo2PageInfoVo(pageInfo);
         chatQueryVOPageInfo.setList(
-                pageInfo.getList().stream().filter(o -> !StringUtils.isEmpty(o.getQueryResult())).map(this::convertTo)
+                pageInfo.getList().stream()
                         .sorted(Comparator.comparingInt(o -> o.getQuestionId().intValue()))
+                        .map(this::convertTo)
                         .collect(Collectors.toList()));
         return chatQueryVOPageInfo;
     }


### PR DESCRIPTION
https://github.com/tencentmusic/supersonic/issues/1538

对话框初始化取最近3条对话，但当最近3条对话query_result都为空时，页面显示为空，且无法上划获取下一分页。
修复前
![image](https://github.com/user-attachments/assets/dcae76eb-83e7-422d-8ecb-970169245987)

修复后
![img_v3_02di_718fe216-bbc6-4355-a6f0-b5daf5d5fadg](https://github.com/user-attachments/assets/668c9fc4-c2aa-4396-9824-1a82e2a65131)
