### PR TITLE
(improvement)(chat)多轮对话增加rewrittenQuery的MapInfo

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -38,9 +38,10 @@ class BatchTest:
         response = requests.post(url, headers=headers, data=json.dumps(data))
         return response.json()
 
-    def execute(self, query_text, queryId):
+    def execute(self, agentId, query_text, queryId):
         url = self.base_url + 'execute'
         data = {
+            'agentId': agentId,
             'queryText': query_text,
             'parseId': 1,
             'chatId': self.chatId,
@@ -75,7 +76,7 @@ def benchmark(url:str, agentId:str, chatId:str, filePath:str, userName:str):
         # 捕获异常，防止程序中断
         try:
             parse_resp = batch_test.parse(question)
-            batch_test.execute(question, parse_resp['data']['queryId'])
+            batch_test.execute(agentId, question, parse_resp['data']['queryId'])
         except Exception as e:
             print('error:', e)
             traceback.print_exc()

--- a/benchmark/requirements.txt
+++ b/benchmark/requirements.txt
@@ -1,4 +1,4 @@
-pandas==2.0.3
+pandas==2.2.2
 PyJWT==2.8.0
 requests==2.28.2
 

--- a/chat/server/src/main/java/com/tencent/supersonic/chat/server/parser/NL2SQLParser.java
+++ b/chat/server/src/main/java/com/tencent/supersonic/chat/server/parser/NL2SQLParser.java
@@ -203,8 +203,10 @@ public class NL2SQLParser implements ChatQueryParser {
         Response<AiMessage> response = chatLanguageModel.generate(prompt.toUserMessage());
         String rewrittenQuery = response.content().text();
         keyPipelineLog.info("NL2SQLParser modelResp:{}", rewrittenQuery);
-
         parseContext.setQueryText(rewrittenQuery);
+        QueryNLReq rewrittenQueryNLReq = QueryReqConverter.buildText2SqlQueryReq(parseContext);
+        MapResp rewrittenQueryMapResult = chatLayerService.performMapping(rewrittenQueryNLReq);
+        parseContext.setMapInfo(rewrittenQueryMapResult.getMapInfo());
         log.info("Last Query: {} Current Query: {}, Rewritten Query: {}",
                 lastQuery.getQueryText(), currentMapResult.getQueryText(), rewrittenQuery);
     }


### PR DESCRIPTION
以下case在多轮对话时需要对重新生成query二次获取mapinfo
优化前
![image](https://github.com/user-attachments/assets/62d8e68d-4b2d-43f3-a024-9a21aa9956a4)

优化后
![image](https://github.com/user-attachments/assets/9d347d30-4df1-42ef-ad90-75d48ff1f6d0)

