### PR TITLE
(improvement)(headless) 智能填充json提取优化

### DIFF
--- a/headless/server/pom.xml
+++ b/headless/server/pom.xml
@@ -125,6 +125,17 @@
             <artifactId>arrow-jdbc</artifactId>
             <version>${arrow-jdbc.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
         
     </dependencies>
 

--- a/headless/server/src/main/java/com/tencent/supersonic/headless/server/service/impl/DimensionServiceImpl.java
+++ b/headless/server/src/main/java/com/tencent/supersonic/headless/server/service/impl/DimensionServiceImpl.java
@@ -319,7 +319,7 @@ public class DimensionServiceImpl extends ServiceImpl<DimensionDOMapper, Dimensi
     public List<String> mockAlias(DimensionReq dimensionReq, String mockType, User user) {
         String mockAlias = aliasGenerateHelper.generateAlias(mockType, dimensionReq.getName(),
                 dimensionReq.getBizName(), "", dimensionReq.getDescription(), false);
-        String ret = mockAlias.replaceAll("`", "").replace("json", "").replace("\n", "").replace(" ", "");
+        String ret = aliasGenerateHelper.extractJsonStringFromAiMessage(mockAlias);
         return JSONObject.parseObject(ret, new TypeReference<List<String>>() {
         });
     }
@@ -346,9 +346,8 @@ public class DimensionServiceImpl extends ServiceImpl<DimensionDOMapper, Dimensi
         }
         String json = aliasGenerateHelper.generateDimensionValueAlias(JSON.toJSONString(valueList));
         log.info("return llm res is :{}", json);
-        String ret = json.replaceAll("`", "").replace("json", "").replace("\n", "").replace(" ", "");
+        String ret = aliasGenerateHelper.extractJsonStringFromAiMessage(json);
         JSONObject jsonObject = JSON.parseObject(ret);
-
         List<DimValueMap> dimValueMapsResp = new ArrayList<>();
         int i = 0;
         for (Map<String, Object> stringObjectMap : resultList) {

--- a/headless/server/src/test/java/com/tencent/supersonic/headless/server/utils/AliasGenerateHelperTest.java
+++ b/headless/server/src/test/java/com/tencent/supersonic/headless/server/utils/AliasGenerateHelperTest.java
@@ -1,0 +1,87 @@
+package com.tencent.supersonic.headless.server.utils;
+import org.junit.jupiter.api.Test;
+
+class AliasGenerateHelperTest {
+
+    @Test
+    void extractJsonStringFromAiMessage1() {
+
+        /**
+         * {
+         *     "name": "Alice",
+         *     "age": 25,
+         *     "city": "New York"
+         * }
+         */
+        String testJson1 = "{\"name\": \"Alice\", \"age\": 25, \"city\": \"New York\"}";
+        AliasGenerateHelper.extractJsonStringFromAiMessage(testJson1);
+    }
+
+    @Test
+    void extractJsonStringFromAiMessage2() {
+
+        /**
+         * ```
+         * {
+         *     "name": "Alice",
+         *     "age": 25,
+         *     "city": "New York"
+         * }
+         * ```
+         */
+        String testJson2 = "```\n"
+                + "{\n"
+                + "    \"name\": \"Alice\",\n"
+                + "    \"age\": 25,\n"
+                + "    \"city\": \"New York\"\n"
+                + "}\n"
+                + "```";
+        AliasGenerateHelper.extractJsonStringFromAiMessage(testJson2);
+
+    }
+
+    @Test
+    void extractJsonStringFromAiMessage3() {
+
+        /**
+         * I understand that you want me to generate a JSON object with two properties: `tran` and `alias`....
+         * ```json
+         * {
+         *     "name": "Alice",
+         *     "age": 25,
+         *     "city": "New York"
+         * }
+         * ```
+         * Please let me know if there is any problem.
+         */
+        String testJson3 = "I understand that you want me to generate a JSON object with two properties: "
+                + "`tran` and `alias`...."
+                + "```json\n"
+                + "{\n"
+                + "    \"name\": \"Alice\",\n"
+                + "    \"age\": 25,\n"
+                + "    \"city\": \"New York\"\n"
+                + "}\n"
+                + "```"
+                + "Please let me know if there is any problem.";
+        AliasGenerateHelper.extractJsonStringFromAiMessage(testJson3);
+
+    }
+
+    @Test
+    void extractJsonStringFromAiMessage4() {
+
+        String testJson4 = "Based on the provided JSON-schema, I will construct the answer as follows:\n"
+                + "\n"
+                + "[\n"
+                + "  \"作者名称\",\n"
+                + "  \"作者姓名\",\n"
+                + "  \"创作者\",\n"
+                + "  \"作者信息\"\n"
+                + "]\n"
+                + "\n"
+                + "This answer conforms to the format described in the JSON-schema";
+        AliasGenerateHelper.extractJsonStringFromAiMessage(testJson4);
+
+    }
+}


### PR DESCRIPTION
目前在Prompt跟随能力较弱的本地模型大模型输出json带有前后冗余字符串，其他格式代码块，一直报错不可用。
优化后在以下本地模型测试通过
qwen2-7b
glm-4-9b-chat
glm3-6b
llama-3-70b

别名填充

![image](https://github.com/user-attachments/assets/4c2a591d-8ea7-4b77-80ef-f4e0498822d0)

纬度值填充
![image](https://github.com/user-attachments/assets/50401c41-2a32-44f7-8451-e94061e1ea80)
