### PR TITLE
(fix)(headless) 修复LLM问题变成术语的问题

### DIFF
--- a/headless/chat/src/main/java/com/tencent/supersonic/headless/chat/mapper/TermDescMapper.java
+++ b/headless/chat/src/main/java/com/tencent/supersonic/headless/chat/mapper/TermDescMapper.java
@@ -23,11 +23,15 @@ public class TermDescMapper extends BaseMapper {
             chatQueryContext.setOriQueryText(chatQueryContext.getQueryText());
         }
         for (SchemaElement schemaElement : termDescriptionToMap) {
+            if (schemaElement.isDescriptionMapped()) {
+                continue;
+            }
             if (chatQueryContext.getQueryText().equals(schemaElement.getDescription())) {
                 schemaElement.setDescriptionMapped(true);
                 continue;
             }
             chatQueryContext.setQueryText(schemaElement.getDescription());
+            break;
         }
         if (CollectionUtils.isEmpty(chatQueryContext.getMapInfo().getTermDescriptionToMap())) {
             chatQueryContext.setQueryText(chatQueryContext.getOriQueryText());

--- a/headless/server/src/main/java/com/tencent/supersonic/headless/server/utils/ChatWorkflowEngine.java
+++ b/headless/server/src/main/java/com/tencent/supersonic/headless/server/utils/ChatWorkflowEngine.java
@@ -47,6 +47,8 @@ public class ChatWorkflowEngine {
                         parseResult.setState(ParseResp.ParseState.FAILED);
                         parseResult.setErrorMsg("No semantic entities can be mapped against user question.");
                         queryCtx.setChatWorkflowState(ChatWorkflowState.FINISHED);
+                    } else if (queryCtx.getMapInfo().needContinueMap()) {
+                        queryCtx.setChatWorkflowState(ChatWorkflowState.MAPPING);
                     } else {
                         queryCtx.setChatWorkflowState(ChatWorkflowState.PARSING);
                     }


### PR DESCRIPTION
#1468  引入了多个术语时死循环的问题
#1580 fix这个问题，引入query变成术语，术语没有Map

设置两条术语
![image](https://github.com/user-attachments/assets/acbfd81b-3d9a-4f49-bdb1-b93816d7af29)

问题：高级作者和低级作者的数量有多少个？

修复前
![img_v3_02e8_e375dd28-2bd0-49f0-aa26-5745edaaca0g](https://github.com/user-attachments/assets/bb06dd11-248b-4022-a3c2-c3f251106fce)

修复后
![img_v3_02e8_baf9d4cc-54ad-4fbd-bacc-d2986a6889cg](https://github.com/user-attachments/assets/4eab9a11-ec84-44e6-a7a0-d7f624e4eb8f)

@lex
@lxwcodemonkey 
