### PR TITLE
(improvement)(common) update OpenAiModelFactory default model

### DIFF
--- a/common/src/main/java/com/tencent/supersonic/common/config/ChatModelParameterConfig.java
+++ b/common/src/main/java/com/tencent/supersonic/common/config/ChatModelParameterConfig.java
@@ -74,7 +74,7 @@ public class ChatModelParameterConfig extends ParameterConfig {
     public static final Parameter CHAT_MODEL_NAME =
             new Parameter(
                     "s2.chat.model.name",
-                    "gpt-3.5-turbo",
+                    "gpt-4o-mini",
                     "ModelName",
                     "",
                     "string",

--- a/common/src/main/java/dev/langchain4j/provider/OpenAiModelFactory.java
+++ b/common/src/main/java/dev/langchain4j/provider/OpenAiModelFactory.java
@@ -16,7 +16,7 @@ public class OpenAiModelFactory implements ModelFactory, InitializingBean {
 
     public static final String PROVIDER = "OPEN_AI";
     public static final String DEFAULT_BASE_URL = "https://api.openai.com/v1";
-    public static final String DEFAULT_MODEL_NAME = "gpt-3.5-turbo";
+    public static final String DEFAULT_MODEL_NAME = "gpt-4o-mini";
     public static final String DEFAULT_EMBEDDING_MODEL_NAME = "text-embedding-ada-002";
 
     @Override


### PR DESCRIPTION
Only gpt-4o-mini model is available for demonstration purposes。
The default demo scene supported used the model gpt-3.5-turbo before, with a maximum length of 1000 tokens. 
It has now been updated to gpt-4o-mini, with a maximum length of 5000 tokens.  