### PR TITLE
(fix)(chat) 修复做embedding检索时，出现重复数据的问题

### DIFF
--- a/common/src/main/java/com/tencent/supersonic/common/service/impl/EmbeddingServiceImpl.java
+++ b/common/src/main/java/com/tencent/supersonic/common/service/impl/EmbeddingServiceImpl.java
@@ -59,6 +59,7 @@ public class EmbeddingServiceImpl implements EmbeddingService {
                     continue;
                 }
                 embeddingStore.add(embedding, query);
+                cache.put(TextSegmentConvert.getQueryId(query), true);
             } catch (Exception e) {
                 log.error(
                         "embeddingModel embed error question: {}, embeddingStore: {}",
@@ -117,6 +118,9 @@ public class EmbeddingServiceImpl implements EmbeddingService {
                             new MetadataFilterBuilder(TextSegmentConvert.QUERY_ID);
                     Filter filter = filterBuilder.isIn(queryIds);
                     inMemoryEmbeddingStore.removeAll(filter);
+                    for (String queryId : queryIds) {
+                        cache.put(queryId, false);
+                    }
                 }
             } else {
                 throw new RuntimeException("Not supported yet.");


### PR DESCRIPTION
每2个小时重新向embeddingstore写metadata数据，写入时未将对应queryId的cache置为true
导致每2个小时全量重复写一次，search时指定maxnum，但因为检索出重复向量，导致search去重后结果少于预期