### PR TITLE
(improvement)(chat) 优化提示工程、重试机制

### DIFF
--- a/headless/chat/src/main/java/com/tencent/supersonic/headless/chat/parser/llm/LLMSqlParser.java
+++ b/headless/chat/src/main/java/com/tencent/supersonic/headless/chat/parser/llm/LLMSqlParser.java
@@ -74,6 +74,11 @@ public class LLMSqlParser implements SemanticParser {
             } catch (Exception e) {
                 log.error("currentRetryRound:{}, runText2SQL failed", currentRetry, e);
             }
+            Double temperature = llmReq.getModelConfig().getTemperature();
+            if (temperature == 0) {
+                // 报错时增加随机性，减少无效重试
+                llmReq.getModelConfig().setTemperature(0.5);
+            }
             currentRetry++;
         }
         if (MapUtils.isEmpty(sqlRespMap)) {


### PR DESCRIPTION
1. 默认及用户设置temperature一般为0，LLM生成格式问题重试时仍然保持一致问题。
2. 目前生成语义SQL不稳定，幻觉导致部分跟随性弱的本地模型经常添加注释导致解析sql失败，使用langchain的json格式化输出并提供thought占位符供大模型发挥。

本地模型llama-3-70b测试40+case未发现sql、json解析报错

