### PR TITLE
(fix)(headless)When reload dictWords, the old data was not cleared

### DIFF
--- a/headless/server/src/main/java/com/tencent/supersonic/headless/server/service/impl/DictWordService.java
+++ b/headless/server/src/main/java/com/tencent/supersonic/headless/server/service/impl/DictWordService.java
@@ -6,6 +6,7 @@ import com.tencent.supersonic.headless.api.pojo.SchemaElementType;
 import com.tencent.supersonic.headless.api.pojo.SemanticSchema;
 import com.tencent.supersonic.headless.chat.knowledge.DictWord;
 import com.tencent.supersonic.headless.chat.knowledge.KnowledgeBaseService;
+import com.tencent.supersonic.headless.chat.knowledge.SearchService;
 import com.tencent.supersonic.headless.chat.knowledge.builder.WordBuilderFactory;
 import com.tencent.supersonic.headless.server.service.SchemaService;
 import lombok.extern.slf4j.Slf4j;
@@ -43,6 +44,7 @@ public class DictWordService {
             return;
         }
         setPreDictWords(dictWords);
+        SearchService.clear();
         knowledgeBaseService.updateOnlineKnowledge(getAllDictWords());
         long duration = System.currentTimeMillis() - startTime;
         log.info("Dictionary has been regularly reloaded in {} milliseconds", duration);


### PR DESCRIPTION
# Pull Request Template

## Description

dictwords有删除和修改，当重新加载dictwords的时候，没有清除或者更新旧的数据，导致com.tencent.supersonic.headless.chat.mapper.SearchMatchStrategy#match仍然能匹配到旧的数据
![image](https://github.com/user-attachments/assets/ce4f96c5-c02a-4999-b76c-441770895279)
