### PR TITLE
(improvement)(headless) Determine if there are any 'GROUP BY' fields that require compatibility with self-queries in WITH clauses.

### DIFF
--- a/common/src/main/java/com/tencent/supersonic/common/jsqlparser/SqlSelectHelper.java
+++ b/common/src/main/java/com/tencent/supersonic/common/jsqlparser/SqlSelectHelper.java
@@ -536,12 +536,17 @@ public class SqlSelectHelper {
         if (!(selectStatement instanceof PlainSelect)) {
             return false;
         }
-        PlainSelect plainSelect = (PlainSelect) selectStatement;
-        GroupByElement groupBy = plainSelect.getGroupBy();
-        if (Objects.nonNull(groupBy)) {
-            GroupByVisitor replaceVisitor = new GroupByVisitor();
-            groupBy.accept(replaceVisitor);
-            return replaceVisitor.isHasAggregateFunction();
+
+        List<PlainSelect> withItem = getWithItem(selectStatement);
+        withItem.add((PlainSelect) selectStatement);
+
+        for (PlainSelect plainSelect : withItem) {
+            GroupByElement groupBy = plainSelect.getGroupBy();
+            if (Objects.nonNull(groupBy)) {
+                GroupByVisitor replaceVisitor = new GroupByVisitor();
+                groupBy.accept(replaceVisitor);
+                return replaceVisitor.isHasAggregateFunction();
+            }
         }
         return false;
     }

--- a/common/src/test/java/com/tencent/supersonic/common/jsqlparser/SqlSelectHelperTest.java
+++ b/common/src/test/java/com/tencent/supersonic/common/jsqlparser/SqlSelectHelperTest.java
@@ -333,4 +333,13 @@ class SqlSelectHelperTest {
         selectFields = SqlSelectHelper.gePureSelectFields(sql);
         Assert.assertEquals(selectFields.size(), 2);
     }
+
+    @Test
+    void testHasGroupBy() {
+        String sql =
+                "WITH DepartmentVisits AS (SELECT 部门, SUM(访问次数) AS pv FROM 超音数数据集 WHERE 数据日期 >= '2024-08-29' "
+                        + "AND 数据日期 <= '2024-09-29' GROUP BY 部门) SELECT COUNT(*) FROM DepartmentVisits WHERE pv > 100";
+        Boolean hasGroupBy = SqlSelectHelper.hasGroupBy(sql);
+        Assert.assertEquals(hasGroupBy, true);
+    }
 }


### PR DESCRIPTION

## Description

Determine if there are any 'GROUP BY' fields that require compatibility with self-queries in WITH clauses.

https://github.com/tencentmusic/supersonic/issues/1718
