### PR TITLE
[improvement][chat]记忆评估性能优化

### DIFF
--- a/chat/server/src/main/java/com/tencent/supersonic/chat/server/memory/MemoryReviewTask.java
+++ b/chat/server/src/main/java/com/tencent/supersonic/chat/server/memory/MemoryReviewTask.java
@@ -1,6 +1,7 @@
 package com.tencent.supersonic.chat.server.memory;
 
 import com.tencent.supersonic.chat.api.pojo.enums.MemoryReviewResult;
+import com.tencent.supersonic.chat.api.pojo.request.ChatMemoryFilter;
 import com.tencent.supersonic.chat.server.agent.Agent;
 import com.tencent.supersonic.chat.server.persistence.dataobject.ChatMemoryDO;
 import com.tencent.supersonic.chat.server.service.AgentService;
@@ -24,6 +25,7 @@ import java.util.Collections;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.List;
 
 @Component
 @Slf4j
@@ -57,24 +59,30 @@ public class MemoryReviewTask {
 
     @Scheduled(fixedDelay = 60 * 1000)
     public void review() {
-        memoryService.getMemoriesForLlmReview().stream().forEach(memory -> {
-            try {
-                processMemory(memory);
-            } catch (Exception e) {
-                log.error("Exception occurred while processing memory with id {}: {}",
-                        memory.getId(), e.getMessage(), e);
+        List<Agent> agentList = agentService.getAgents();
+        for (Agent agent : agentList) {
+            if(!agent.enableMemoryReview()){
+                continue;
             }
-        });
+            ChatMemoryFilter chatMemoryFilter = ChatMemoryFilter.builder().agentId(agent.getId()).build();
+            memoryService.getMemories(chatMemoryFilter).stream().forEach(memory -> {
+                try {
+                    processMemory(memory, agent);
+                } catch (Exception e) {
+                    log.error("Exception occurred while processing memory with id {}: {}",
+                            memory.getId(), e.getMessage(), e);
+                }
+            });
+        }
     }
 
-    private void processMemory(ChatMemoryDO m) {
-        Agent chatAgent = agentService.getAgent(m.getAgentId());
-        if (Objects.isNull(chatAgent)) {
+    private void processMemory(ChatMemoryDO m, Agent agent) {
+        if (Objects.isNull(agent)) {
             log.warn("Agent id {} not found or memory review disabled", m.getAgentId());
             return;
         }
 
-        ChatApp chatApp = chatAgent.getChatAppConfig().get(APP_KEY);
+        ChatApp chatApp = agent.getChatAppConfig().get(APP_KEY);
         if (Objects.isNull(chatApp) || !chatApp.isEnable()) {
             return;
         }
@@ -90,7 +98,7 @@ public class MemoryReviewTask {
                     response);
             processResponse(response, m);
         } else {
-            log.debug("ChatLanguageModel not found for agent:{}", chatAgent.getId());
+            log.debug("ChatLanguageModel not found for agent:{}", agent.getId());
         }
     }
 


### PR DESCRIPTION
当前记忆评估为每分钟定时执行一次
先扫描所有待定memory，获取各个记忆Agent配置
修改为：
先扫描获取启用记忆评估Agent，再扫描memory

优化逻辑提升性能，减少从旧版迁移过来后的cpu占用