### PR TITLE
fix(semanticModel): model options not exist when creating new dataset

### DIFF
--- a/webapp/packages/supersonic-fe/config/proxy.ts
+++ b/webapp/packages/supersonic-fe/config/proxy.ts
@@ -1,7 +1,7 @@
 export default {
   dev: {
     '/api/': {
-      target: 'http://127.0.0.1:9080',
+      target: 'http://10.177.43.90:9080',
       changeOrigin: true,
     },
   },

--- a/webapp/packages/supersonic-fe/src/pages/SemanticModel/View/components/DataSetTable.tsx
+++ b/webapp/packages/supersonic-fe/src/pages/SemanticModel/View/components/DataSetTable.tsx
@@ -15,9 +15,10 @@ import ViewSearchFormModal from './ViewSearchFormModal';
 type Props = {
   dataSetList: ISemantic.IDatasetItem[];
   disabledEdit?: boolean;
+  isCurrent: boolean;
 };
 
-const DataSetTable: React.FC<Props> = ({ dataSetList, disabledEdit = false }) => {
+const DataSetTable: React.FC<Props> = ({ dataSetList, disabledEdit = false, isCurrent }) => {
   const domainModel = useModel('SemanticModel.domainData');
   const { selectDomainId } = domainModel;
 
@@ -51,8 +52,8 @@ const DataSetTable: React.FC<Props> = ({ dataSetList, disabledEdit = false }) =>
 
   useEffect(() => {
     // queryDataSetList();
-    queryDomainAllModel();
-  }, [selectDomainId]);
+    if (isCurrent) queryDomainAllModel();
+  }, [selectDomainId, isCurrent]);
 
   const queryDataSetList = async () => {
     setLoading(true);

--- a/webapp/packages/supersonic-fe/src/pages/SemanticModel/View/index.tsx
+++ b/webapp/packages/supersonic-fe/src/pages/SemanticModel/View/index.tsx
@@ -3,14 +3,15 @@ import { ISemantic } from '../data';
 import DataSetTable from './components/DataSetTable';
 
 type Props = {
+  isCurrent: boolean;
   disabledEdit?: boolean;
   dataSetList: ISemantic.IDatasetItem[];
 };
 
-const View: React.FC<Props> = ({ dataSetList, disabledEdit = false }) => {
+const View: React.FC<Props> = ({ isCurrent, dataSetList, disabledEdit = false }) => {
   return (
     <div style={{ padding: '15px 20px' }}>
-      <DataSetTable disabledEdit={disabledEdit} dataSetList={dataSetList} />
+      <DataSetTable isCurrent={isCurrent} disabledEdit={disabledEdit} dataSetList={dataSetList} />
     </div>
   );
 };

--- a/webapp/packages/supersonic-fe/src/pages/SemanticModel/components/DomainManagerTab.tsx
+++ b/webapp/packages/supersonic-fe/src/pages/SemanticModel/components/DomainManagerTab.tsx
@@ -50,7 +50,7 @@ const DomainManagerTab: React.FC<Props> = ({
       label: '数据集管理',
       key: 'overview',
       hidden: !!domainData?.parentId,
-      children: <View dataSetList={dataSetList} />,
+      children: <View isCurrent={activeKey === 'overview'} dataSetList={dataSetList} />,
     },
     {
       label: '模型管理',


### PR DESCRIPTION
## Description

语义建模中，【模型管理】Tab下新增模型后，切回【数据集管理】创建数据集，可选模型中没有新增的模型选项

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)