### PR TITLE
(fix)(auth)jwt bug

### DIFF
--- a/auth/api/src/main/java/com/tencent/supersonic/auth/api/authentication/pojo/UserWithPassword.java
+++ b/auth/api/src/main/java/com/tencent/supersonic/auth/api/authentication/pojo/UserWithPassword.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import static com.tencent.supersonic.auth.api.authentication.constant.UserConstants.TOKEN_CREATE_TIME;
 import static com.tencent.supersonic.auth.api.authentication.constant.UserConstants.TOKEN_IS_ADMIN;
 import static com.tencent.supersonic.auth.api.authentication.constant.UserConstants.TOKEN_USER_DISPLAY_NAME;
+import static com.tencent.supersonic.auth.api.authentication.constant.UserConstants.TOKEN_USER_EMAIL;
 import static com.tencent.supersonic.auth.api.authentication.constant.UserConstants.TOKEN_USER_ID;
 import static com.tencent.supersonic.auth.api.authentication.constant.UserConstants.TOKEN_USER_NAME;
 import static com.tencent.supersonic.auth.api.authentication.constant.UserConstants.TOKEN_USER_PASSWORD;
@@ -38,6 +39,7 @@ public class UserWithPassword extends User {
         claims.put(TOKEN_USER_NAME, StringUtils.isEmpty(user.getName()) ? "" : user.getName());
         claims.put(TOKEN_USER_PASSWORD,
                 StringUtils.isEmpty(user.getPassword()) ? "" : user.getPassword());
+        claims.put(TOKEN_USER_EMAIL, StringUtils.isEmpty(user.getEmail()) ? "" : user.getEmail());
         claims.put(TOKEN_USER_DISPLAY_NAME, user.getDisplayName());
         claims.put(TOKEN_CREATE_TIME, System.currentTimeMillis());
         claims.put(TOKEN_IS_ADMIN, user.getIsAdmin());


### PR DESCRIPTION
补充用户电子邮件信息到JWT Claims

描述：在生成JWT令牌时，补充了用户电子邮件信息到Claims中。具体来说，添加了TOKEN_USER_EMAIL键值对，用于存储用户的电子邮件地址。

变更：
1. 添加了TOKEN_USER_EMAIL常量的导入
2. 在convert方法中添加了claims.put(TOKEN_USER_EMAIL, StringUtils.isEmpty(user.getEmail()) ? "" : user.getEmail());语句，以将用户电子邮件信息添加到Claims中

目的：
为了使JWT令牌中包含用户的电子邮件信息，以便于后续的身份验证和授权流程。