### PR TITLE
fix(agent): 助理管理列表切换分页后启用禁用状态展示错误

### DIFF
--- a/webapp/packages/supersonic-fe/src/pages/Agent/AgentsSection.tsx
+++ b/webapp/packages/supersonic-fe/src/pages/Agent/AgentsSection.tsx
@@ -64,6 +64,7 @@ const AgentsSection: React.FC<Props> = ({
               }}
             >
               <Switch
+                key={agent.id}
                 size="small"
                 defaultChecked={status === 1}
                 onChange={(value) => {


### PR DESCRIPTION
# Pull Request Template

## Description

修复助理管理列表页，切换分页后，启用禁用状态错误的问题

<img width="497" alt="image" src="https://github.com/user-attachments/assets/4034a220-b7de-4f96-8a7e-24d47eaf8651">


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
