### PR TITLE
对UserStrategy可配置性进行增强

### DIFF
--- a/auth/api/src/main/java/com/tencent/supersonic/auth/api/authentication/config/AuthenticationConfig.java
+++ b/auth/api/src/main/java/com/tencent/supersonic/auth/api/authentication/config/AuthenticationConfig.java
@@ -18,6 +18,9 @@ public class AuthenticationConfig {
     @Value("${s2.authentication.include.path:/api}")
     private String includePath;
 
+    @Value("${s2.authentication.strategy:http}")
+    private String strategy;
+
     @Value("${s2.authentication.enable:false}")
     private boolean enabled;
 

--- a/auth/api/src/main/java/com/tencent/supersonic/auth/api/authentication/service/UserStrategy.java
+++ b/auth/api/src/main/java/com/tencent/supersonic/auth/api/authentication/service/UserStrategy.java
@@ -7,6 +7,8 @@ import com.tencent.supersonic.common.pojo.User;
 
 public interface UserStrategy {
 
+    String getStrategyName();
+
     boolean accept(boolean isEnableAuthentication);
 
     User findUser(HttpServletRequest request, HttpServletResponse response);

--- a/auth/authentication/src/main/java/com/tencent/supersonic/auth/authentication/strategy/FakeUserStrategy.java
+++ b/auth/authentication/src/main/java/com/tencent/supersonic/auth/authentication/strategy/FakeUserStrategy.java
@@ -10,6 +10,13 @@ import org.springframework.stereotype.Service;
 @Service
 public class FakeUserStrategy implements UserStrategy {
 
+    public static final String STRATEGY_NAME = "fake";
+
+    @Override
+    public String getStrategyName() {
+        return STRATEGY_NAME;
+    }
+
     @Override
     public boolean accept(boolean isEnableAuthentication) {
         return !isEnableAuthentication;

--- a/auth/authentication/src/main/java/com/tencent/supersonic/auth/authentication/strategy/HttpHeaderUserStrategy.java
+++ b/auth/authentication/src/main/java/com/tencent/supersonic/auth/authentication/strategy/HttpHeaderUserStrategy.java
@@ -15,10 +15,16 @@ import java.util.Optional;
 @Service
 public class HttpHeaderUserStrategy implements UserStrategy {
 
+    public static final String STRATEGY_NAME = "http";
     private final TokenService tokenService;
 
     public HttpHeaderUserStrategy(TokenService tokenService) {
         this.tokenService = tokenService;
+    }
+
+    @Override
+    public String getStrategyName() {
+        return STRATEGY_NAME;
     }
 
     @Override


### PR DESCRIPTION


## Description

当我集成服务时，需要对UserStrategy进行扩展，但是当下的实现在UserStrategyFactory并不支持。
所以扩展配置，当用户配置自己的strategy时，能使用自己的扩展。


## Additional information
在不改变原有行为下，用户可以通过s2.authentication.strategy来配置自己的strategy实现