### PR TITLE
Fix chat req&rsp no args constructor

### DIFF
--- a/chat/api/src/main/java/com/tencent/supersonic/chat/api/pojo/request/ChatConfigBaseReq.java
+++ b/chat/api/src/main/java/com/tencent/supersonic/chat/api/pojo/request/ChatConfigBaseReq.java
@@ -8,7 +8,6 @@ import java.util.List;
 
 /** extended information command about model */
 @Data
-@ToString
 public class ChatConfigBaseReq {
 
     private Long modelId;

--- a/chat/api/src/main/java/com/tencent/supersonic/chat/api/pojo/request/ChatMemoryUpdateReq.java
+++ b/chat/api/src/main/java/com/tencent/supersonic/chat/api/pojo/request/ChatMemoryUpdateReq.java
@@ -4,11 +4,15 @@ import javax.validation.constraints.NotNull;
 
 import com.tencent.supersonic.chat.api.pojo.enums.MemoryReviewResult;
 import com.tencent.supersonic.chat.api.pojo.enums.MemoryStatus;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ChatMemoryUpdateReq {
 
     @NotNull(message = "id不可为空")

--- a/chat/api/src/main/java/com/tencent/supersonic/chat/api/pojo/request/ItemNameVisibility.java
+++ b/chat/api/src/main/java/com/tencent/supersonic/chat/api/pojo/request/ItemNameVisibility.java
@@ -4,7 +4,6 @@ import lombok.Data;
 import lombok.ToString;
 
 @Data
-@ToString
 public class ItemNameVisibility {
 
     private ItemNameVisibilityInfo aggVisibilityInfo;

--- a/chat/api/src/main/java/com/tencent/supersonic/chat/api/pojo/request/ItemNameVisibilityInfo.java
+++ b/chat/api/src/main/java/com/tencent/supersonic/chat/api/pojo/request/ItemNameVisibilityInfo.java
@@ -7,7 +7,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Data
-@ToString
 public class ItemNameVisibilityInfo {
 
     /** invisible dimensions */

--- a/chat/api/src/main/java/com/tencent/supersonic/chat/api/pojo/request/ItemVisibility.java
+++ b/chat/api/src/main/java/com/tencent/supersonic/chat/api/pojo/request/ItemVisibility.java
@@ -7,7 +7,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Data
-@ToString
 public class ItemVisibility {
 
     /** invisible dimensions */

--- a/chat/api/src/main/java/com/tencent/supersonic/chat/api/pojo/request/RecommendedQuestionReq.java
+++ b/chat/api/src/main/java/com/tencent/supersonic/chat/api/pojo/request/RecommendedQuestionReq.java
@@ -6,7 +6,6 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Data
-@ToString
 @AllArgsConstructor
 @NoArgsConstructor
 public class RecommendedQuestionReq {

--- a/chat/api/src/main/java/com/tencent/supersonic/chat/api/pojo/response/DictLatestTaskResp.java
+++ b/chat/api/src/main/java/com/tencent/supersonic/chat/api/pojo/response/DictLatestTaskResp.java
@@ -6,7 +6,6 @@ import lombok.ToString;
 
 import java.util.Date;
 
-@ToString
 @Data
 public class DictLatestTaskResp {
 

--- a/chat/api/src/main/java/com/tencent/supersonic/chat/api/pojo/response/RecommendQuestionResp.java
+++ b/chat/api/src/main/java/com/tencent/supersonic/chat/api/pojo/response/RecommendQuestionResp.java
@@ -3,10 +3,12 @@ package com.tencent.supersonic.chat.api.pojo.response;
 import com.tencent.supersonic.chat.api.pojo.request.RecommendedQuestionReq;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Data
+@NoArgsConstructor
 @AllArgsConstructor
 public class RecommendQuestionResp {
     private Long modelId;

--- a/chat/api/src/main/java/com/tencent/supersonic/chat/api/pojo/response/SimilarQueryRecallResp.java
+++ b/chat/api/src/main/java/com/tencent/supersonic/chat/api/pojo/response/SimilarQueryRecallResp.java
@@ -1,10 +1,14 @@
 package com.tencent.supersonic.chat.api.pojo.response;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class SimilarQueryRecallResp {
 
     private Long queryId;

--- a/chat/server/src/main/java/com/tencent/supersonic/chat/server/service/impl/ChatQueryServiceImpl.java
+++ b/chat/server/src/main/java/com/tencent/supersonic/chat/server/service/impl/ChatQueryServiceImpl.java
@@ -230,7 +230,8 @@ public class ChatQueryServiceImpl implements ChatQueryService {
         return queryResult;
     }
 
-    private boolean checkMetricReplace(ChatQueryDataReq chatQueryDataReq, SemanticParseInfo parseInfo) {
+    private boolean checkMetricReplace(ChatQueryDataReq chatQueryDataReq,
+            SemanticParseInfo parseInfo) {
         List<String> oriFields = getFieldsFromSql(parseInfo);
         Set<SchemaElement> metrics = chatQueryDataReq.getMetrics();
         if (CollectionUtils.isEmpty(oriFields) || CollectionUtils.isEmpty(metrics)) {
@@ -242,7 +243,7 @@ public class ChatQueryServiceImpl implements ChatQueryService {
     }
 
     private String replaceFilters(ChatQueryDataReq queryData, SemanticParseInfo parseInfo,
-                                  DataSetSchema dataSetSchema) {
+            DataSetSchema dataSetSchema) {
         String correctorSql = parseInfo.getSqlInfo().getCorrectedS2SQL();
         log.info("correctorSql before replacing:{}", correctorSql);
         // get where filter and having filter


### PR DESCRIPTION


## Description

高版本的fastjson会反序列化失败，因为没有默认的构造函数，如下所示，所以把chat-api下的看得见的lombok都清理了下
```
com.alibaba.fastjson.JSONException: default constructor not found. class com.tencent.supersonic.chat.api.pojo.response.SimilarQueryRecallResp
	at com.alibaba.fastjson.util.JavaBeanInfo.build(JavaBeanInfo.java:574)
	at com.alibaba.fastjson.parser.ParserConfig.createJavaBeanDeserializer(ParserConfig.java:993)
	at com.alibaba.fastjson.parser.ParserConfig.getDeserializer(ParserConfig.java:879)
	at com.alibaba.fastjson.parser.ParserConfig.getDeserializer(ParserConfig.java:584)
	at com.alibaba.fastjson.parser.DefaultJSONParser.parseArray(DefaultJSONParser.java:749)
	at com.alibaba.fastjson.parser.DefaultJSONParser.parseArray(DefaultJSONParser.java:726)
	at com.alibaba.fastjson.parser.DefaultJSONParser.parseArray(DefaultJSONParser.java:721)
	at com.alibaba.fastjson.JSON.parseArray(JSON.java:643)
	at com.alibaba.fastjson.JSON.parseArray(JSON.java:623)
	at com.tencent.supersonic.chat.server.persistence.repository.impl.ChatQueryRepositoryImpl.convertTo(ChatQueryRepositoryImpl.java:121)
	at com.tencent.supersonic.chat.server.persistence.repository.impl.ChatQueryRepositoryImpl.getChatQuery(ChatQueryRepositoryImpl.java:86)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
```