### PR TITLE
SAP HANA DATABASE Source support improvement[优化SAPhana数据库的支持]

### DIFF
--- a/common/src/main/java/com/tencent/supersonic/common/jsqlparser/FieldAliasReplaceNameVisitor.java
+++ b/common/src/main/java/com/tencent/supersonic/common/jsqlparser/FieldAliasReplaceNameVisitor.java
@@ -1,0 +1,41 @@
+package com.tencent.supersonic.common.jsqlparser;
+
+import net.sf.jsqlparser.statement.select.SelectItem;
+import net.sf.jsqlparser.statement.select.SelectItemVisitorAdapter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+
+import net.sf.jsqlparser.expression.Alias;
+
+public class FieldAliasReplaceNameVisitor extends SelectItemVisitorAdapter {
+    private Map<String, String> fieldNameMap;
+
+    private Map<String, String> aliasToActualExpression = new HashMap<>();
+
+    public FieldAliasReplaceNameVisitor(Map<String, String> fieldNameMap) {
+        this.fieldNameMap = fieldNameMap;
+    }
+
+    @Override
+    public void visit(SelectItem selectExpressionItem) {
+        Alias alias = selectExpressionItem.getAlias();
+        if (alias == null) {
+            return;
+        }
+        String aliasName = alias.getName();
+        String replaceValue = fieldNameMap.get(aliasName);
+        if (StringUtils.isBlank(replaceValue)) {
+            return;
+        }
+
+        aliasToActualExpression.put(aliasName, replaceValue);
+        alias.setName(replaceValue);
+    }
+
+    public Map<String, String> getAliasToActualExpression() {
+        return aliasToActualExpression;
+    }
+}

--- a/common/src/main/java/com/tencent/supersonic/common/jsqlparser/SqlReplaceHelper.java
+++ b/common/src/main/java/com/tencent/supersonic/common/jsqlparser/SqlReplaceHelper.java
@@ -449,6 +449,22 @@ public class SqlReplaceHelper {
         }
     }
 
+    public static String replaceAliasFieldName(String sql, Map<String, String> fieldNameMap) {
+        Select selectStatement = SqlSelectHelper.getSelect(sql);
+        if (!(selectStatement instanceof PlainSelect)) {
+            return sql;
+        }
+        PlainSelect plainSelect = (PlainSelect) selectStatement;
+        FieldAliasReplaceNameVisitor visitor = new FieldAliasReplaceNameVisitor(fieldNameMap);
+        for (SelectItem selectItem : plainSelect.getSelectItems()) {
+            selectItem.accept(visitor);
+        }
+        Map<String, String> aliasToActualExpression = visitor.getAliasToActualExpression();
+        if (Objects.nonNull(aliasToActualExpression) && !aliasToActualExpression.isEmpty()) {
+            return replaceFields(selectStatement.toString(), aliasToActualExpression, true);
+        }
+        return selectStatement.toString();
+    }
     public static String replaceAlias(String sql) {
         Select selectStatement = SqlSelectHelper.getSelect(sql);
         if (!(selectStatement instanceof PlainSelect)) {

--- a/common/src/main/java/dev/langchain4j/provider/ZhipuModelFactory.java
+++ b/common/src/main/java/dev/langchain4j/provider/ZhipuModelFactory.java
@@ -9,6 +9,7 @@ import dev.langchain4j.model.zhipu.ZhipuAiChatModel;
 import dev.langchain4j.model.zhipu.ZhipuAiEmbeddingModel;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.stereotype.Service;
+import static java.time.Duration.ofSeconds;
 
 @Service
 public class ZhipuModelFactory implements ModelFactory, InitializingBean {
@@ -30,7 +31,8 @@ public class ZhipuModelFactory implements ModelFactory, InitializingBean {
     public EmbeddingModel createEmbeddingModel(EmbeddingModelConfig embeddingModelConfig) {
         return ZhipuAiEmbeddingModel.builder().baseUrl(embeddingModelConfig.getBaseUrl())
                 .apiKey(embeddingModelConfig.getApiKey()).model(embeddingModelConfig.getModelName())
-                .maxRetries(embeddingModelConfig.getMaxRetries())
+                .maxRetries(embeddingModelConfig.getMaxRetries()).callTimeout(ofSeconds(60))
+                .connectTimeout(ofSeconds(60)).writeTimeout(ofSeconds(60)).readTimeout(ofSeconds(60))
                 .logRequests(embeddingModelConfig.getLogRequests())
                 .logResponses(embeddingModelConfig.getLogResponses()).build();
     }

--- a/common/src/test/java/com/tencent/supersonic/common/jsqlparser/SqlReplaceHelperTest.java
+++ b/common/src/test/java/com/tencent/supersonic/common/jsqlparser/SqlReplaceHelperTest.java
@@ -325,6 +325,38 @@ class SqlReplaceHelperTest {
     }
 
     @Test
+    void testReplaceAliasFieldName() {
+            Map<String, String> map = new HashMap<>();
+            map.put("总访问次数", "\"总访问次数\"");
+            map.put("访问次数", "\"访问次数\"");
+            String sql = "select 部门, sum(访问次数) as 总访问次数 from 超音数 where "
+                            + "datediff('day', 数据日期, '2023-09-05') <= 3 group by 部门 order by 总访问次数 desc limit 10";
+            String replaceSql = SqlReplaceHelper.replaceAliasFieldName(sql, map);
+            System.out.println(replaceSql);
+            Assert.assertEquals("SELECT 部门, sum(访问次数) AS \"总访问次数\" FROM 超音数 WHERE "
+                            + "datediff('day', 数据日期, '2023-09-05') <= 3 GROUP BY 部门 ORDER BY \"总访问次数\" DESC LIMIT 10",
+                            replaceSql);
+
+            sql = "select 部门, sum(访问次数) as 总访问次数 from 超音数 where "
+                            + "(datediff('day', 数据日期, '2023-09-05') <= 3) and 数据日期 = '2023-10-10' "
+                            + "group by 部门 order by 总访问次数 desc limit 10";
+            replaceSql = SqlReplaceHelper.replaceAliasFieldName(sql, map);
+            System.out.println(replaceSql);
+            Assert.assertEquals("SELECT 部门, sum(访问次数) AS \"总访问次数\" FROM 超音数 WHERE "
+                            + "(datediff('day', 数据日期, '2023-09-05') <= 3) AND 数据日期 = '2023-10-10' "
+                            + "GROUP BY 部门 ORDER BY \"总访问次数\" DESC LIMIT 10", replaceSql);
+
+            sql = "select 部门, sum(访问次数) as 访问次数 from 超音数 where "
+                            + "(datediff('day', 数据日期, '2023-09-05') <= 3) and 数据日期 = '2023-10-10' "
+                            + "group by 部门 order by 访问次数 desc limit 10";
+            replaceSql = SqlReplaceHelper.replaceAliasFieldName(sql, map);
+            System.out.println(replaceSql);
+            Assert.assertEquals("SELECT 部门, sum(\"访问次数\") AS \"访问次数\" FROM 超音数 WHERE (datediff('day', 数据日期, "
+                            + "'2023-09-05') <= 3) AND 数据日期 = '2023-10-10' GROUP BY 部门 ORDER BY \"访问次数\" DESC LIMIT 10",
+                            replaceSql);
+    }
+
+    @Test
     void testReplaceAggAliasOrderbyField() {
         String sql = "SELECT SUM(访问次数) AS top10总播放量 FROM (SELECT 部门, SUM(访问次数) AS 访问次数 FROM 超音数  "
                 + "GROUP BY 部门 ORDER BY SUM(访问次数) DESC LIMIT 10) AS top10";

--- a/headless/core/src/main/java/com/tencent/supersonic/headless/core/adaptor/db/HanadbAdaptor.java
+++ b/headless/core/src/main/java/com/tencent/supersonic/headless/core/adaptor/db/HanadbAdaptor.java
@@ -7,7 +7,7 @@ public class HanadbAdaptor extends DefaultDbAdaptor {
 
     @Override
     public String rewriteSql(String sql) {
-        return sql.replaceAll("`", "\"");
+        return sql.replaceAll("`(.*?)`", "\"$1\"").replaceAll("\"([A-Z0-9_]+?)\"", "$1");
     }
 
 }

--- a/headless/core/src/main/java/com/tencent/supersonic/headless/core/translator/parser/calcite/node/SemanticNode.java
+++ b/headless/core/src/main/java/com/tencent/supersonic/headless/core/translator/parser/calcite/node/SemanticNode.java
@@ -80,9 +80,13 @@ public abstract class SemanticNode {
                 scope.getValidator().getCatalogReader().getRootSchema(), engineType);
         if (Configuration.getSqlAdvisor(sqlValidatorWithHints, engineType).getReservedAndKeyWords()
                 .contains(expression.toUpperCase())) {
-            expression = String.format("`%s`", expression);
+            if (engineType == EngineType.HANADB) {
+                expression = String.format("\"%s\"", expression);
+            } else {
+                expression = String.format("`%s`", expression);
+            }
         }
-        SqlParser sqlParser =
+        SqlParser sqlParser = 
                 SqlParser.create(expression, Configuration.getParserConfig(engineType));
         SqlNode sqlNode = sqlParser.parseExpression();
         scope.validateExpr(sqlNode);


### PR DESCRIPTION
# Pull Request Template

## Description

SAP HANA数据作为SAP ERP的数据库，内部有数量巨大的表数据，使用supersonic进行数据挖掘与探索也会不一个不错的选择，在目前的测试中发现SAP HANA数据库中存在以下与普通数据库不兼容的地方：
- 在sql语句中，如果没有使用双引号，那么会自动的把字段或是数据库表名称转换成大写，但是saphana又允许创建小写的字段或是数据库表。
- SAP hana关键字比标准的sql标准多出一些[关键字](https://help.sap.com/docs/SAP_HANA_PLATFORM/4fe29514fd584807ac9f2a04f6754767/28bcd6af3eb6437892719f7c27a8a285.html)。所以在使用calcite进行SQL优化时，会把这些额外的关键字加上了双引号，导致异常。

在此交提交修正有以下的调整：

- 在SqlQueryConverter-convertNameToBizName处理之后，针对sap hana进行特别处理，对非大写的字段进行处理，使用双引号包含读取字段，别名字段，如果在parse阶段处理，会导致模型字段翻译失败。
- 针对问题2，在sql rewrite阶段进行字符串替换，针对calcite进行兼容处理。

另外修改一个使用zhipu模型embedding时，程序报错缺少对应的时间设置参数，只是简单的增加默认的60秒超时。

### Incompatibilities in the SAP HANA Database:

- In SQL statements, if double quotes are not used, the field or database table names are automatically converted to uppercase. However, SAP HANA allows the creation of lowercase fields or database tables.
- SAP HANA has more [keywords]（https://help.sap.com/docs/SAP_HANA_PLATFORM/4fe29514fd584807ac9f2a04f6754767/28bcd6af3eb6437892719f7c27a8a285.html） than the standard SQL standard. Therefore, when using Calcite for SQL optimization, these extra keywords are quoted, causing exceptions. for example:
- CURRENT_UTCDATE
- CURRENT_UTCTIME
- CURRENT_UTCTIMESTAMP

### Adjustments in This Submission:

- After processing in `SqlQueryConverter-convertNameToBizName`, special handling for SAP HANA is done. For non-uppercase fields, double quotes are used to enclose fields and alias fields. Processing this during the parse stage will result in model field translation failure.
- For issue 2, string replacement is done during the SQL rewrite stage to handle Calcite compatibility.

### Additional Modification:

A simple change is made to add a default 60-second timeout parameter to prevent the program from reporting an error when using the Zhipu model embedding.


### Databases Supporting Lowercase Field Names:

- Databases that support lowercase field names can better align with the natural case sensitivity required in certain applications.

### Support for Complex SAP HANA SQL:

These databases can support complex SQL, such as:
- Nested subqueries
- Common Table Expressions (CTEs)
- Window functions
- Recursive queries
- Advanced joins (e.g., full outer joins, cross joins)


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [X] Test A
  新增处理功能点方法SqlReplaceHelper->replaceAliasFieldName,用于替换sql中的as字段名。
- [X] Test B

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional information

Any additional information, configuration or data that might be necessary to reproduce the issue.

针对复杂HANA语句处理：
![image](https://github.com/user-attachments/assets/82be80fe-ce47-43d7-a634-aa8cbe31e88c)

use the zhipu model for embeding test
![image](https://github.com/user-attachments/assets/3dfe8d35-1059-4c69-b17f-e3d485accea6)


可支持使用小写字段的数据库,也可支持以下复杂的sql:

```sql
SELECT
  SCHEMA_NAME,
  TABLE_NAME,
  TOTAL,
  TOTAL_MOD,
  INSERTS,
  UPDATES,
  DELETES,
  REPLACES,
  SELECTS,
  TO_VARCHAR(LAST_MODIFY_TIME, 'YYYY/MM/DD HH24:MI:SS') LAST_MODIFY_TIME
FROM
( SELECT
    TS.SCHEMA_NAME,
    TS.TABLE_NAME,
    TS.INSERT_COUNT + TS.DELETE_COUNT + TS.UPDATE_COUNT + TS.REPLACE_COUNT TOTAL_MOD,
    TS.INSERT_COUNT + TS.DELETE_COUNT + TS.UPDATE_COUNT + TS.REPLACE_COUNT + TS.SELECT_COUNT TOTAL,
    TS.INSERT_COUNT INSERTS,
    TS.UPDATE_COUNT UPDATES,
    TS.DELETE_COUNT DELETES,
    TS.REPLACE_COUNT REPLACES,
    TS.SELECT_COUNT SELECTS,
    BI.RESULT_ROWS,
    CASE BI.TIMEZONE WHEN 'UTC' THEN ADD_SECONDS(TS.LAST_MODIFY_TIME, SECONDS_BETWEEN(CURRENT_TIMESTAMP, CURRENT_UTCTIMESTAMP)) ELSE TS.LAST_MODIFY_TIME END LAST_MODIFY_TIME,
    ROW_NUMBER () OVER 
    ( ORDER BY
        MAP(BI.ORDER_BY, 'TABLE', TS.SCHEMA_NAME, ''),
        MAP(BI.ORDER_BY, 'TABLE', TS.TABLE_NAME, ''),
        MAP(BI.ORDER_BY, 
          'TOTAL', TS.INSERT_COUNT + TS.DELETE_COUNT + TS.UPDATE_COUNT + TS.REPLACE_COUNT + TS.SELECT_COUNT,
          'TOTAL_MOD', TS.INSERT_COUNT + TS.DELETE_COUNT + TS.UPDATE_COUNT + TS.REPLACE_COUNT,
          'INSERT', TS.INSERT_COUNT,
          'UPDATE', TS.UPDATE_COUNT,
          'DELETE', TS.DELETE_COUNT,
          'REPLACE', TS.REPLACE_COUNT,
          'SELECT', TS.SELECT_COUNT) DESC
    ) ROW_NUM
  FROM
  ( SELECT                /* Modification section */
      'SERVER' TIMEZONE,                              /* SERVER, UTC */
      '%' SCHEMA_NAME,
      '%' TABLE_NAME,
      'TOTAL' ORDER_BY,        /* TABLE, TOTAL, TOTAL_MOD, INSERT, UPDATE, DELETE, REPLACE, SELECT */
      50 RESULT_ROWS
    FROM
      DUMMY
  ) BI,
    M_TABLE_STATISTICS TS
  WHERE
    TS.SCHEMA_NAME LIKE BI.SCHEMA_NAME AND
    TS.TABLE_NAME LIKE BI.TABLE_NAME
  ORDER BY
    MAP(BI.ORDER_BY, 'TABLE', TS.SCHEMA_NAME, ''),
    MAP(BI.ORDER_BY, 'TABLE', TS.TABLE_NAME, ''),
    MAP(BI.ORDER_BY, 
      'TOTAL', TS.INSERT_COUNT + TS.DELETE_COUNT + TS.UPDATE_COUNT + TS.REPLACE_COUNT,
      'INSERT', TS.INSERT_COUNT,
      'UPDATE', TS.UPDATE_COUNT,
      'DELETE', TS.DELETE_COUNT,
      'REPLACE', TS.REPLACE_COUNT) DESC
)
WHERE
  ( RESULT_ROWS = -1 OR ROW_NUM <= RESULT_ROWS )
```