### PR TITLE
[fix][common]Support 'BETWEEN AND' query condition parameter parsing …

### DIFF
--- a/common/src/main/java/com/tencent/supersonic/common/jsqlparser/FieldAndValueAcquireVisitor.java
+++ b/common/src/main/java/com/tencent/supersonic/common/jsqlparser/FieldAndValueAcquireVisitor.java
@@ -7,15 +7,7 @@ import net.sf.jsqlparser.expression.ExpressionVisitorAdapter;
 import net.sf.jsqlparser.expression.Function;
 import net.sf.jsqlparser.expression.LongValue;
 import net.sf.jsqlparser.expression.StringValue;
-import net.sf.jsqlparser.expression.operators.relational.ComparisonOperator;
-import net.sf.jsqlparser.expression.operators.relational.EqualsTo;
-import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
-import net.sf.jsqlparser.expression.operators.relational.GreaterThan;
-import net.sf.jsqlparser.expression.operators.relational.GreaterThanEquals;
-import net.sf.jsqlparser.expression.operators.relational.InExpression;
-import net.sf.jsqlparser.expression.operators.relational.LikeExpression;
-import net.sf.jsqlparser.expression.operators.relational.MinorThan;
-import net.sf.jsqlparser.expression.operators.relational.MinorThanEquals;
+import net.sf.jsqlparser.expression.operators.relational.*;
 import net.sf.jsqlparser.schema.Column;
 import org.apache.commons.collections.CollectionUtils;
 
@@ -32,6 +24,29 @@ public class FieldAndValueAcquireVisitor extends ExpressionVisitorAdapter {
 
     public FieldAndValueAcquireVisitor(Set<FieldExpression> fieldExpressions) {
         this.fieldExpressions = fieldExpressions;
+    }
+
+    public void visit(Between between) {
+        Expression leftExpression = between.getLeftExpression();
+        String columnName = null;
+        if (leftExpression instanceof Column) {
+            Column column = (Column) leftExpression;
+            columnName = column.getColumnName();
+        }
+        Expression betweenExpressionStart = between.getBetweenExpressionStart();
+        Expression betweenExpressionEnd = between.getBetweenExpressionEnd();
+
+        FieldExpression fieldExpressionStart = new FieldExpression();
+        fieldExpressionStart.setFieldName(columnName);
+        fieldExpressionStart.setFieldValue(getFieldValue(betweenExpressionStart));
+        fieldExpressionStart.setOperator(JsqlConstants.GREATER_THAN_EQUALS);
+        fieldExpressions.add(fieldExpressionStart);
+
+        FieldExpression fieldExpressionEnd = new FieldExpression();
+        fieldExpressionEnd.setFieldName(columnName);
+        fieldExpressionEnd.setFieldValue(getFieldValue(betweenExpressionEnd));
+        fieldExpressionEnd.setOperator(JsqlConstants.MINOR_THAN_EQUALS);
+        fieldExpressions.add(fieldExpressionEnd);
     }
 
     public void visit(LikeExpression expr) {


### PR DESCRIPTION
…`CURRENT`. #1972

# Pull Request Template

## Description

对应Issues #1972 的bug修复

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

文本转sql时，让大模型返回的语义SQL 的查询条件 出现 between and 时，会出现查询条件变更不生效的现象 

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional information

Any additional information, configuration or data that might be necessary to reproduce the issue.