### PR TITLE
QueryUtils.isNumberType method add type real、tinyint、smallint for database fields

### DIFF
--- a/headless/server/src/main/java/com/tencent/supersonic/headless/server/service/impl/DimensionServiceImpl.java
+++ b/headless/server/src/main/java/com/tencent/supersonic/headless/server/service/impl/DimensionServiceImpl.java
@@ -465,10 +465,11 @@ public class DimensionServiceImpl extends ServiceImpl<DimensionDOMapper, Dimensi
     }
 
     private boolean isChange(DimensionReq dimensionReq, DimensionResp dimensionResp) {
+        boolean isNameChange = !dimensionReq.getName().equals(dimensionResp.getName());
         boolean isExtChange = !new EqualsBuilder()
                 .append(dimensionReq.getExt(), dimensionResp.getExt()).isEquals();
         boolean isTypeParamChange =
                 !Objects.equals(dimensionReq.getTypeParams(), dimensionResp.getTypeParams());
-        return isExtChange || isTypeParamChange;
+        return isNameChange || isExtChange || isTypeParamChange;
     }
 }

--- a/headless/server/src/main/java/com/tencent/supersonic/headless/server/utils/QueryUtils.java
+++ b/headless/server/src/main/java/com/tencent/supersonic/headless/server/utils/QueryUtils.java
@@ -120,7 +120,8 @@ public class QueryUtils {
             return false;
         }
         return type.equalsIgnoreCase("int") || type.equalsIgnoreCase("bigint")
-                || type.equalsIgnoreCase("float") || type.equalsIgnoreCase("double")
+                || type.equalsIgnoreCase("tinyint") || type.equalsIgnoreCase("smallint")
+                || type.equalsIgnoreCase("float") || type.equalsIgnoreCase("double") || type.equalsIgnoreCase("real")
                 || type.equalsIgnoreCase("numeric") || type.toLowerCase().startsWith("decimal")
                 || type.toLowerCase().startsWith("uint") || type.toLowerCase().startsWith("int");
     }


### PR DESCRIPTION
# Pull Request Template

## Description

if Returning a real type field from the database cause showType filed error.
QueryUtils.isNumberType method add type real、tinyint、smallint for database fields

QueryUtils.processColumn

// set showType
if (nameTypePair.containsKey(nameEn)) {
    column.setShowType(nameTypePair.get(nameEn));
}
if (!nameTypePair.containsKey(nameEn) && isNumberType(column.getType())) {
    column.setShowType(SemanticType.*NUMBER*.name());
}
if (StringUtils.*isEmpty*(column.getShowType())) {
    column.setShowType(SemanticType.*CATEGORY*.name());
}


- [√] Bug fix (non-breaking change which fixes an issue)