### PR TITLE
【bug】Webapp fix error TS2551: Property 'nameEn' does not exist on type 'ColumnType'. Did you mean 'name'?

### DIFF
--- a/assembly/bin/supersonic-build.sh
+++ b/assembly/bin/supersonic-build.sh
@@ -56,6 +56,11 @@ function packageRelease {
   # package webapp
   tar xvf supersonic-webapp.tar.gz
   mv supersonic-webapp webapp
+  # check webapp build result
+  if [ $? -ne 0 ]; then
+      echo "Failed to get supersonic webapp package."
+      exit 1
+  fi
   json='{"env": "''"}'
   echo $json > webapp/supersonic.config.json
   mv webapp $release_dir/

--- a/webapp/packages/chat-sdk/src/typings.d.ts
+++ b/webapp/packages/chat-sdk/src/typings.d.ts
@@ -94,6 +94,7 @@ type TopNConfig = {
 
 type ColumnType = {
   name: string;
+  nameEn: string;
   type: string;
 };
 


### PR DESCRIPTION
# Pull Request Template

## Description

![image](https://github.com/user-attachments/assets/d9a9d2ca-9324-4f2b-81cb-ab6c257ead34)
## Type of change

Please delete options that are not relevant.

- [*] Bug fix (non-breaking change which fixes an issue)

     src/index.tsx → dist/index.es.js...
     [INFO] [!] (plugin rpt2) RollupError: src/components/ChatItem/index.tsx:423:66 - error TS2551: Property 'nameEn' does not exist on type 'ColumnType'. Did you mean 'name'?
     
     423           const columnName = queryColumns?.find(column => column.nameEn === key)?.name || key;
                                                                          ~~~~~~
     
       src/common/type.ts:180:3
         180   name: string;
               ~~~~
         'name' is declared here.
     
     src/index.tsx
     
         at error (/home/docker/volcano-supersonic/webapp/node_modules/.pnpm/rollup@3.29.5/node_modules/rollup/dist/shared/rollup.js:353:30)
         at Object.error (/home/docker/volcano-supersonic/webapp/node_modules/.pnpm/rollup@3.29.5/node_modules/rollup/dist/shared/rollup.js:1721:20)
     [INFO]     at RollupContext.error (/home/docker/volcano-supersonic/webapp/node_modules/.pnpm/rollup-plugin-typescript2@0.36.0_rollup@3.29.5_typescript@4.9.5/node_modules/rollup-plugin-typescript2/src/context.ts:35:17)
         at /home/docker/volcano-supersonic/webapp/node_modules/.pnpm/rollup-plugin-typescript2@0.36.0_rollup@3.29.5_typescript@4.9.5/node_modules/rollup-plugin-typescript2/src/diagnostics.ts:70:17
         at Array.forEach ()
         at printDiagnostics (/home/docker/volcano-supersonic/webapp/node_modules/.pnpm/rollup-plugin-typescript2@0.36.0_rollup@3.29.5_typescript@4.9.5/node_modules/rollup-plugin-typescript2/src/diagnostics.ts:42:14)
         at typecheckFile (/home/docker/volcano-supersonic/webapp/node_modules/.pnpm/rollup-plugin-typescript2@0.36.0_rollup@3.29.5_typescript@4.9.5/node_modules/rollup-plugin-typescript2/src/index.ts:67:3)
         at Object. (/home/docker/volcano-supersonic/webapp/node_modules/.pnpm/rollup-plugin-

## How Has This Been Tested?
