### PR TITLE
[fix][headless] Fix models cannot be deleted if related indicators/dimensions are marked as deleted.

### DIFF
--- a/headless/server/src/main/java/com/tencent/supersonic/headless/server/service/impl/ModelServiceImpl.java
+++ b/headless/server/src/main/java/com/tencent/supersonic/headless/server/service/impl/ModelServiceImpl.java
@@ -61,15 +61,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -372,7 +364,9 @@ public class ModelServiceImpl implements ModelService {
         metaFilter.setModelIds(Lists.newArrayList(modelId));
         List<MetricResp> metricResps = metricService.getMetrics(metaFilter);
         List<DimensionResp> dimensionResps = dimensionService.getDimensions(metaFilter);
-        if (!CollectionUtils.isEmpty(metricResps) || !CollectionUtils.isEmpty(dimensionResps)) {
+        boolean validMetric = metricResps.stream().anyMatch(metricResp -> Objects.equals(metricResp.getStatus(), StatusEnum.ONLINE.getCode()));
+        boolean validDimension = dimensionResps.stream().anyMatch(dimensionResp -> Objects.equals(dimensionResp.getStatus(), StatusEnum.ONLINE.getCode()));
+        if (validMetric || validDimension) {
             throw new RuntimeException("存在基于该模型创建的指标和维度, 暂不能删除, 请确认");
         }
     }


### PR DESCRIPTION
Description
This PR fixes an issue where models cannot be deleted if their related indicators or dimensions are marked as deleted. The problem occurred because the system was still referencing the deleted indicators/dimensions, preventing the model from being removed. This fix ensures that models can be deleted even if their related indicators/dimensions are marked as deleted, by properly handling the references and cleanup process.

Type of change
Bug fix (non-breaking change which fixes an issue)