### PR TITLE
[fix][headless-fe] Fix the issue of incorrect column sorting in charts.

### DIFF
--- a/webapp/packages/chat-sdk/src/components/ChatMsg/Bar/index.tsx
+++ b/webapp/packages/chat-sdk/src/components/ChatMsg/Bar/index.tsx
@@ -56,9 +56,7 @@ const BarChart: React.FC<Props> = ({
     } else {
       instanceObj = instanceRef.current;
     }
-    const data = (queryResults || []).sort(
-      (a: any, b: any) => b[metricColumnName] - a[metricColumnName]
-    );
+    const data = (queryResults || []);
     const xData = data.map(item =>
       item[categoryColumnName] !== undefined ? item[categoryColumnName] : '未知'
     );


### PR DESCRIPTION
## Description
The issue was related to incorrect time sorting in the charts, where the data was being re-sorted in the frontend code, overriding the intended sorting order specified in the SQL query (e.g., using ORDER BY for time or other fields). This led to a mismatch between the expected and displayed data order.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)