### PR TITLE
[fix][project] Fix the issue of SpringDoc not working.

### DIFF
--- a/launchers/standalone/pom.xml
+++ b/launchers/standalone/pom.xml
@@ -18,23 +18,14 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.1.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-expression</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-beans</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-webmvc</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>com.github.xiaoymin</groupId>
+            <artifactId>knife4j-openapi3-jakarta-spring-boot-starter</artifactId>
+            <version>4.5.0</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>4.0.2</version>
         </dependency>
         <dependency>
             <groupId>com.tencent.supersonic</groupId>

--- a/launchers/standalone/src/main/resources/application.yaml
+++ b/launchers/standalone/src/main/resources/application.yaml
@@ -30,9 +30,29 @@ logging:
 springdoc:
   swagger-ui:
     path: /swagger-ui.html
-    enabled: true
+    tags-sorter: alpha
+    operations-sorter: alpha
   api-docs:
     path: /v3/api-docs
-    enabled: true
+  group-configs:
+    - group: 'default'
+      paths-to-match: '/**'
   packages-to-scan: com.tencent.supersonic
   paths-to-match: /api/chat/**,/api/semantic/**
+
+knife4j:
+  enable: true
+  openapi:
+    title: 'SuperSonic API Documentation'
+    description: 'SuperSonic API Documentation'
+    version: v1.0
+  setting:
+    language: zh-CN
+#  basic:
+#    enable: true
+#    username: test
+#    password: 123456#
+  documents:
+    default:
+      title: ChatBI API Documents
+      description: ChatBI API Documents

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,6 @@
         <spotless.version>2.27.1</spotless.version>
         <spotless.skip>false</spotless.skip>
         <stax2.version>4.2.1</stax2.version>
-        <io.springfox.version>3.0.0</io.springfox.version>
         <aws-java-sdk.version>1.12.780</aws-java-sdk.version>
     </properties>
 


### PR DESCRIPTION
## Description
During the testing phase, the integration of Spring Boot 3 with Springdoc-OpenAPI works as expected. However, in the production environment, the following error occurs:

> Unable to render this definition
> The provided definition does not specify a valid version field.
> Please indicate a valid Swagger or OpenAPl version field.
> Supported version fields are swagger: "2.0" and those that
> match openapi: 3.x.y(for example, openapi: 3.1.0 ).

This error indicates that the Spring openapi specification generated by springdoc-openapi is not being recognized correctly in the production environment, likely due to compatibility issues between Spring Boot 3 and springdoc-openapi.

To resolve this issue, I replaced springdoc-openapi with knife4j-openapi3. After making this change, the application runs successfully without any errors in both testing and production environments.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
