### PR TITLE
feat:upgrade hanlp 1.8.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <pagehelper.spring.version>2.1.0</pagehelper.spring.version>
         <mybatis.version>3.5.3</mybatis.version>
         <guava.version>32.0.0-jre</guava.version>
-        <hanlp.version>portable-1.8.3</hanlp.version>
+        <hanlp.version>portable-1.8.4</hanlp.version>
         <hadoop.version>2.7.2</hadoop.version>
         <commons.lang.version>2.6</commons.lang.version>
         <commons.lang3.version>3.7</commons.lang3.version>


### PR DESCRIPTION
# Pull Request Template

## Description
输入  "queryText": "请提供公版App激活设备数最多的前五个二级品类的设备分布情况。",
![image](https://github.com/user-attachments/assets/416c90e2-cedb-4b10-8c12-9bca947075ad)

解析成了如下，并不是期望的效果：
<img width="759" alt="image" src="https://github.com/user-attachments/assets/f442ed48-0fa4-4c67-923f-41c5d4d0e036" />

<img width="626" alt="image" src="https://github.com/user-attachments/assets/510a4e7b-eba1-4a80-b7d9-696efff6415f" />

<img width="752" alt="image" src="https://github.com/user-attachments/assets/f178ea12-695f-41d3-97d1-c0487a1e0a6e" />
<img width="632" alt="image" src="https://github.com/user-attachments/assets/0499c5c4-3bcc-4d66-9f4d-da7df2dd7d22" />

<img width="657" alt="image" src="https://github.com/user-attachments/assets/acdbe100-98ec-4f3e-ac90-83715c6a0194" />


## Type of change

Please delete options that are not relevant.
- [*] Breaking change (fix or feature that would cause existing functionality to not work as expected)

@jerryjzhang 能不能升级到1.8.6验证一下呢？直接升级到1.8.6还跑不起来（1.8.4是可以的）

目前自定义分词库都是配置文件，是不是做到界面化配置更好呢？

