### PR TITLE
fix:java.lang.NullPointerException: "dateConf" is null

### DIFF
--- a/headless/server/src/main/java/com/tencent/supersonic/headless/server/utils/DictUtils.java
+++ b/headless/server/src/main/java/com/tencent/supersonic/headless/server/utils/DictUtils.java
@@ -425,8 +425,12 @@ public class DictUtils {
                 .format(DateTimeFormatter.ofPattern(format));
         String end = LocalDate.now().minusDays(itemValueDateEnd)
                 .format(DateTimeFormatter.ofPattern(format));
-        return String.format("( %s >= '%s' and %s <= '%s' )", dateConf.getDateField(), start,
-                dateConf.getDateField(), end);
+        if (Objects.nonNull(dateConf)) {
+            return String.format("( %s >= '%s' and %s <= '%s' )", dateConf.getDateField(), start,
+                    dateConf.getDateField(), end);
+        } else {
+            return String.format("( %s >= '%s' and %s <= '%s' )", "dt", start, "dt", end);
+        }
     }
 
     private String generateDictDateFilter(DictItemResp dictItemResp) {
@@ -440,7 +444,7 @@ public class DictUtils {
         }
         // 未进行设置
         if (Objects.isNull(config) || Objects.isNull(config.getDateConf())) {
-            return defaultDateFilter(config.getDateConf());
+            return defaultDateFilter(null);
         }
         // 全表扫描
         if (DateConf.DateMode.ALL.equals(config.getDateConf().getDateMode())) {


### PR DESCRIPTION
…onic.common.pojo.DateConf.getDateField()" because "dateConf" is null
![image](https://github.com/user-attachments/assets/739ae53f-2b8a-42f2-9a1e-644b2026c711)

## Type of change

Please delete options that are not relevant.

- [*] Bug fix (non-breaking change which fixes an issue)

默认用dt是否合适？还是直接放开返回 “” 合适呢？
