### PR TITLE
fix: issues/2132 for Trino syntax

### DIFF
--- a/headless/core/src/main/java/com/tencent/supersonic/headless/core/adaptor/db/PrestoAdaptor.java
+++ b/headless/core/src/main/java/com/tencent/supersonic/headless/core/adaptor/db/PrestoAdaptor.java
@@ -83,6 +83,7 @@ public class PrestoAdaptor extends BaseDbAdaptor {
 
     @Override
     public String rewriteSql(String sql) {
+        sql = sql.replaceAll("`", "\"");
         return sql;
     }
 }


### PR DESCRIPTION
## Description
Currently if I configure a Trino data source, the generated SQL always reports error like this:

> StatementCallback; uncategorized SQLException for SQL [with t_5 as (SELECT "src1_amazon_products"."parent_asin", "src1_amazon_products"."rating_number", "src1_amazon_products"."main_category", "src1_amazon_products"."title"
FROM
(SELECT *
FROM
"amazon_sight2"."products") AS "src1_amazon_products")
SELECT main_category, parent_asin, title, SUM(rating_number) AS \`_用户的评价数量_\` FROM t_5 WHERE rating_number > 0 GROUP BY main_category, parent_asin, title ORDER BY \`_用户的评价数量_\` DESC LIMIT 20]; SQL state [null]; error code [1]; Query failed (#20250307_074754_02430_ithqp): line 6:65: backquoted identifiers are not supported; use double quotes to quote identifiers

<img width="1437" alt="image" src="https://github.com/user-attachments/assets/e0f47640-30bf-4197-a0e0-c0066be4ab97" />


The reason is that, backquoted was appeared in the generated SQL even if including this PR's change (https://github.com/tencentmusic/supersonic/pull/2137). There might be better solution, but I see in the PostgresqlAdaptor, it just replace all backquoted with "\"", that is what Trino need, so I made the same change, and then it works.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I have a local deployment with Trino as the data source. You can create a dataset and then test it. Before this change, every query will fail. After apply it, supersonic works good.

<img width="1435" alt="image" src="https://github.com/user-attachments/assets/d50c6d05-0005-46f6-8a37-9b9db6787210" />

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

## Additional information

Any additional information, configuration or data that might be necessary to reproduce the issue.