### PR TITLE
fix-common-因缓存无法存记忆

### DIFF
--- a/common/src/main/java/com/tencent/supersonic/common/service/impl/EmbeddingServiceImpl.java
+++ b/common/src/main/java/com/tencent/supersonic/common/service/impl/EmbeddingServiceImpl.java
@@ -49,7 +49,7 @@ public class EmbeddingServiceImpl implements EmbeddingService {
             try {
                 EmbeddingModel embeddingModel = ModelProvider.getEmbeddingModel();
                 Embedding embedding = embeddingModel.embed(question).content();
-                boolean existSegment = existSegment(embeddingStore, query, embedding);
+                boolean existSegment = existSegment(collectionName,embeddingStore, query, embedding);
                 if (existSegment) {
                     continue;
                 }
@@ -62,14 +62,14 @@ public class EmbeddingServiceImpl implements EmbeddingService {
         }
     }
 
-    private boolean existSegment(EmbeddingStore embeddingStore, TextSegment query,
+    private boolean existSegment(String collectionName,EmbeddingStore embeddingStore, TextSegment query,
             Embedding embedding) {
         String queryId = TextSegmentConvert.getQueryId(query);
         if (queryId == null) {
             return false;
         }
         // Check cache first
-        Boolean cachedResult = cache.getIfPresent(queryId);
+        Boolean cachedResult = cache.getIfPresent(collectionName+queryId);
         if (cachedResult != null) {
             return cachedResult;
         }
@@ -82,7 +82,7 @@ public class EmbeddingServiceImpl implements EmbeddingService {
         EmbeddingSearchResult result = embeddingStore.search(request);
         List<EmbeddingMatch<TextSegment>> relevant = result.matches();
         boolean exists = CollectionUtils.isNotEmpty(relevant);
-        cache.put(queryId, exists);
+        cache.put(collectionName+queryId, exists);
         return exists;
     }
 


### PR DESCRIPTION
如果在一个助理问了一个问题，然后再另外一个助理上也问了相同的问题，只要一个助理存到了记忆，其他助理无法存。导致其他助理无法应用该问题。（虽然是相同的问题，但是范围可以不一样）

所以将缓存添加collectionName 前缀，这样不同助理应用记忆能独立