### PR TITLE
修复同一模型被多个数据集引用时问题

### DIFF
--- a/headless/chat/src/main/java/com/tencent/supersonic/headless/chat/knowledge/MapResult.java
+++ b/headless/chat/src/main/java/com/tencent/supersonic/headless/chat/knowledge/MapResult.java
@@ -22,4 +22,9 @@ public abstract class MapResult implements Serializable {
         return this.getMapKey().equals(otherResult.getMapKey())
                 && this.similarity < otherResult.similarity;
     }
+
+    public Boolean lessOrEqualSimilar(MapResult otherResult) {
+        return this.getMapKey().equals(otherResult.getMapKey())
+                && this.similarity <= otherResult.similarity;
+    }
 }

--- a/headless/chat/src/main/java/com/tencent/supersonic/headless/chat/knowledge/MetaEmbeddingService.java
+++ b/headless/chat/src/main/java/com/tencent/supersonic/headless/chat/knowledge/MetaEmbeddingService.java
@@ -75,6 +75,8 @@ public class MetaEmbeddingService {
             return dataSetIds.stream().map(dataSetId -> {
                 Retrieval newRetrieval = new Retrieval();
                 BeanUtils.copyProperties(retrieval, newRetrieval);
+                HashMap<String, Object> newMetadata = new HashMap<>(retrieval.getMetadata());
+                newRetrieval.setMetadata(newMetadata);
                 newRetrieval.getMetadata().putIfAbsent("dataSetId",
                         dataSetId + Constants.UNDERLINE);
                 return newRetrieval;

--- a/headless/chat/src/main/java/com/tencent/supersonic/headless/chat/mapper/BaseMatchStrategy.java
+++ b/headless/chat/src/main/java/com/tencent/supersonic/headless/chat/mapper/BaseMatchStrategy.java
@@ -56,7 +56,8 @@ public abstract class BaseMatchStrategy<T extends MapResult> implements MatchStr
         for (T oneRoundResult : oneRoundResults) {
             if (existResults.contains(oneRoundResult)) {
                 boolean isDeleted = existResults.removeIf(existResult -> {
-                    boolean delete = existResult.lessSimilar(oneRoundResult);
+//                    boolean delete = existResult.lessSimilar(oneRoundResult);
+                    boolean delete = existResult.lessOrEqualSimilar(oneRoundResult);
                     if (delete) {
                         log.debug("deleted existResult:{}", existResult);
                     }


### PR DESCRIPTION
1.浅拷贝导致meta中map的元数据被更改，新对象通过copy后因数据集key已存在导致其余数据集id未能正确创建。
 2.因为copy相似度值相等，小于判断会导致不同数据集id的对象被移除，改为小于等于防止不同数据集Id的EmbeddingResult被移除。

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Also include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional information

Any additional information, configuration or data that might be necessary to reproduce the issue.