### PR TITLE
Fix PostgreSQL adapter to properly use schema parameters in metadata queries

### DIFF
--- a/headless/core/src/main/java/com/tencent/supersonic/headless/core/adaptor/db/PostgresqlAdaptor.java
+++ b/headless/core/src/main/java/com/tencent/supersonic/headless/core/adaptor/db/PostgresqlAdaptor.java
@@ -88,7 +88,7 @@ public class PostgresqlAdaptor extends BaseDbAdaptor {
         List<String> tablesAndViews = Lists.newArrayList();
         DatabaseMetaData metaData = getDatabaseMetaData(connectionInfo);
         try (ResultSet resultSet =
-                metaData.getTables(null, null, null, new String[] {"TABLE", "VIEW"})) {
+                metaData.getTables(null, schemaName, null, new String[] {"TABLE", "VIEW"})) {
             while (resultSet.next()) {
                 String name = resultSet.getString("TABLE_NAME");
                 tablesAndViews.add(name);
@@ -103,7 +103,7 @@ public class PostgresqlAdaptor extends BaseDbAdaptor {
             String tableName) throws SQLException {
         List<DBColumn> dbColumns = Lists.newArrayList();
         DatabaseMetaData metaData = getDatabaseMetaData(connectInfo);
-        ResultSet columns = metaData.getColumns(null, null, tableName, null);
+        ResultSet columns = metaData.getColumns(null, schemaName, tableName, null);
         while (columns.next()) {
             String columnName = columns.getString("COLUMN_NAME");
             String dataType = columns.getString("TYPE_NAME");


### PR DESCRIPTION
# Pull Request: Fix PostgreSQL adapter to properly use schema parameters in metadata queries

## Description

当前PostgreSQL适配器在获取表和列信息时没有指定Schema参数，导致查询会返回数据库中所有schema的信息，这不仅影响性能，还会带来不必要的数据传输。本PR修复了`PostgresqlAdaptor`类中的`getTables`和`getColumns`方法，确保它们正确使用提供的schema参数来查询数据库元数据。

这个修复对于拥有多个schema的PostgreSQL数据库特别重要，可以显著提高查询效率并避免获取不必要的数据。

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

我通过以下方式测试了这个修复：

- [x] 在包含多个schema的PostgreSQL数据库上测试，验证只返回指定schema中的表信息

测试环境：
- PostgreSQL 16
- Java 21
- 测试数据库包含3个schema，每个schema中至少有5个表

## Additional information

修改的核心是在`metaData.getTables()`和`metaData.getColumns()`方法调用中正确使用schemaName参数，而不是传入null。这确保了元数据查询仅限于指定的schema范围内。

## 关联Issue
#2207 