### PR TITLE
[Fix][headless-fe] Error when copying access token

### DIFF
--- a/webapp/packages/supersonic-fe/src/components/RightContent/AccessTokensModal.tsx
+++ b/webapp/packages/supersonic-fe/src/components/RightContent/AccessTokensModal.tsx
@@ -7,7 +7,7 @@ import {
   getUserAccessTokens,
   removeAccessToken,
 } from '@/services/user';
-import { encryptPassword, encryptKey } from '@/utils/utils';
+import { encryptPassword, encryptKey, copyText } from '@/utils/utils';
 import { API } from '@/services/API';
 import { EditableProTable, ProColumns } from '@ant-design/pro-components';
 import { CopyOutlined } from '@ant-design/icons';
@@ -84,8 +84,7 @@ const ChangePasswordModal = forwardRef<IRef>((_, ref) => {
               type="link"
               size="small"
               onClick={() => {
-                navigator.clipboard.writeText(record.token || '');
-                message.info('已复制到剪贴板');
+                copyText(record.token || '');
               }}
             >
               <CopyOutlined />


### PR DESCRIPTION
## Description
Clicking the "Copy" button for the access token fails silently without copying the token to the clipboard.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)