### PR TITLE
[Improvement][headless] Replace deprecated LangChain4j APIs

### DIFF
--- a/common/src/main/java/dev/langchain4j/model/dify/DifyAiChatModel.java
+++ b/common/src/main/java/dev/langchain4j/model/dify/DifyAiChatModel.java
@@ -9,6 +9,7 @@ import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.model.chat.ChatLanguageModel;
 import dev.langchain4j.model.output.Response;
 import lombok.Builder;
+import lombok.Setter;
 
 import java.util.List;
 
@@ -32,6 +33,7 @@ public class DifyAiChatModel implements ChatLanguageModel {
     private final Double temperature;
     private final Long timeOut;
 
+    @Setter
     private String userName;
 
     @Builder
@@ -54,7 +56,7 @@ public class DifyAiChatModel implements ChatLanguageModel {
     @Override
     public String generate(String message) {
         DifyResult difyResult = this.difyClient.generate(message, this.getUserName());
-        return difyResult.getAnswer().toString();
+        return difyResult.getAnswer();
     }
 
     @Override
@@ -67,7 +69,7 @@ public class DifyAiChatModel implements ChatLanguageModel {
             List<ToolSpecification> toolSpecifications) {
         ensureNotEmpty(messages, "messages");
         DifyResult difyResult =
-                this.difyClient.generate(messages.get(0).text(), this.getUserName());
+                this.difyClient.generate(messages.get(0).toString(), this.getUserName());
         System.out.println(difyResult.toString());
 
         if (!isNullOrEmpty(toolSpecifications)) {
@@ -84,12 +86,8 @@ public class DifyAiChatModel implements ChatLanguageModel {
                 toolSpecification != null ? singletonList(toolSpecification) : null);
     }
 
-    public void setUserName(String userName) {
-        this.userName = userName;
-    }
-
     public String getUserName() {
-        return null == userName ? "zhaodongsheng" : userName;
+        return null == userName ? "admin" : userName;
     }
 
 }

--- a/common/src/main/java/dev/langchain4j/model/openai/OpenAiChatModel.java
+++ b/common/src/main/java/dev/langchain4j/model/openai/OpenAiChatModel.java
@@ -52,7 +52,7 @@ import static dev.langchain4j.model.openai.InternalOpenAiHelper.toOpenAiMessages
 import static dev.langchain4j.model.openai.InternalOpenAiHelper.toOpenAiResponseFormat;
 import static dev.langchain4j.model.openai.InternalOpenAiHelper.toTools;
 import static dev.langchain4j.model.openai.InternalOpenAiHelper.tokenUsageFrom;
-import static dev.langchain4j.model.openai.OpenAiModelName.GPT_3_5_TURBO;
+import static dev.langchain4j.model.openai.OpenAiChatModelName.GPT_3_5_TURBO;
 import static dev.langchain4j.spi.ServiceHelper.loadFactories;
 import static java.time.Duration.ofSeconds;
 import static java.util.Collections.emptyList;
@@ -111,7 +111,7 @@ public class OpenAiChatModel implements ChatLanguageModel, TokenCountEstimator {
                 .connectTimeout(timeout).readTimeout(timeout).writeTimeout(timeout).proxy(proxy)
                 .logRequests(logRequests).logResponses(logResponses).userAgent(DEFAULT_USER_AGENT)
                 .customHeaders(customHeaders).build();
-        this.modelName = getOrDefault(modelName, GPT_3_5_TURBO);
+        this.modelName = getOrDefault(modelName, GPT_3_5_TURBO.name());
         this.apiVersion = apiVersion;
         this.temperature = getOrDefault(temperature, 0.7);
         this.topP = topP;
@@ -130,7 +130,7 @@ public class OpenAiChatModel implements ChatLanguageModel, TokenCountEstimator {
         this.strictTools = getOrDefault(strictTools, false);
         this.parallelToolCalls = parallelToolCalls;
         this.maxRetries = getOrDefault(maxRetries, 3);
-        this.tokenizer = getOrDefault(tokenizer, OpenAiTokenizer::new);
+        this.tokenizer = getOrDefault(tokenizer, () -> new OpenAiTokenizer(this.modelName));
         this.listeners = listeners == null ? emptyList() : new ArrayList<>(listeners);
     }
 


### PR DESCRIPTION
## Description
As we approach the official release of LangChain4j, it's necessary to migrate all deprecated APIs to their recommended replacements. This update ensures compatibility with the stable version and takes advantage of improved functionality.

## Type of change
- [ ] Improvement