### PR TITLE
修复headless中字段查询及多轮对话使用问题

### DIFF
--- a/headless/chat/src/main/java/com/tencent/supersonic/headless/chat/mapper/EmbeddingMatchStrategy.java
+++ b/headless/chat/src/main/java/com/tencent/supersonic/headless/chat/mapper/EmbeddingMatchStrategy.java
@@ -167,7 +167,7 @@ public class EmbeddingMatchStrategy extends BatchMatchStrategy<EmbeddingResult> 
             variable.put("retrievedInfo", JSONObject.toJSONString(results));
 
             Prompt prompt = PromptTemplate.from(LLM_FILTER_PROMPT).apply(variable);
-            ChatLanguageModel chatLanguageModel = ModelProvider.getChatModel();
+            ChatLanguageModel chatLanguageModel = ModelProvider.getChatModel(chatQueryContext.getRequest().getChatAppConfig().get("REWRITE_MULTI_TURN").getChatModelConfig());
             String response = chatLanguageModel.generate(prompt.toUserMessage().singleText());
 
             if (StringUtils.isBlank(response)) {

--- a/headless/core/src/main/java/com/tencent/supersonic/headless/core/translator/parser/SqlQueryParser.java
+++ b/headless/core/src/main/java/com/tencent/supersonic/headless/core/translator/parser/SqlQueryParser.java
@@ -48,15 +48,16 @@ public class SqlQueryParser implements QueryParser {
         List<String> queryFields = SqlSelectHelper.getAllSelectFields(sqlQuery.getSql());
         Set<String> queryAliases = SqlSelectHelper.getAliasFields(sqlQuery.getSql());
         Set<String> ontologyMetricsDimensions = Collections.synchronizedSet(new HashSet<String>());
+        Set<String> ontologyBizNameMetricsDimensions = Collections.synchronizedSet(new HashSet<String>());
         queryFields.removeAll(queryAliases);
         Ontology ontology = queryStatement.getOntology();
         OntologyQuery ontologyQuery = buildOntologyQuery(ontology, queryFields);
         Set<String> queryFieldsSet = new HashSet<>(queryFields);
-        ontologyQuery.getMetrics().forEach(m -> ontologyMetricsDimensions.add(m.getName()));
-        ontologyQuery.getDimensions().forEach(d -> ontologyMetricsDimensions.add(d.getName()));
+        ontologyQuery.getMetrics().forEach(m -> {ontologyMetricsDimensions.add(m.getName()); ontologyBizNameMetricsDimensions.add(m.getBizName());});
+        ontologyQuery.getDimensions().forEach(d -> {ontologyMetricsDimensions.add(d.getName()); ontologyBizNameMetricsDimensions.add(d.getBizName());});
         // check if there are fields not matched with any metric or dimension
 
-        if (!queryFieldsSet.containsAll(ontologyMetricsDimensions)) {
+        if (!(queryFieldsSet.containsAll(ontologyMetricsDimensions)||queryFieldsSet.containsAll(ontologyBizNameMetricsDimensions))) {
             List<String> semanticFields = Lists.newArrayList();
             ontologyQuery.getMetrics().forEach(m -> semanticFields.add(m.getName()));
             ontologyQuery.getDimensions().forEach(d -> semanticFields.add(d.getName()));

--- a/headless/core/src/main/java/com/tencent/supersonic/headless/core/translator/parser/SqlQueryParser.java
+++ b/headless/core/src/main/java/com/tencent/supersonic/headless/core/translator/parser/SqlQueryParser.java
@@ -47,12 +47,16 @@ public class SqlQueryParser implements QueryParser {
         SqlQuery sqlQuery = queryStatement.getSqlQuery();
         List<String> queryFields = SqlSelectHelper.getAllSelectFields(sqlQuery.getSql());
         Set<String> queryAliases = SqlSelectHelper.getAliasFields(sqlQuery.getSql());
+        Set<String> ontologyMetricsDimensions = Collections.synchronizedSet(new HashSet<String>());
         queryFields.removeAll(queryAliases);
         Ontology ontology = queryStatement.getOntology();
         OntologyQuery ontologyQuery = buildOntologyQuery(ontology, queryFields);
+        Set<String> queryFieldsSet = new HashSet<>(queryFields);
+        ontologyQuery.getMetrics().forEach(m -> ontologyMetricsDimensions.add(m.getName()));
+        ontologyQuery.getDimensions().forEach(d -> ontologyMetricsDimensions.add(d.getName()));
         // check if there are fields not matched with any metric or dimension
-        if (queryFields.size() > ontologyQuery.getMetrics().size()
-                + ontologyQuery.getDimensions().size()) {
+
+        if (!queryFieldsSet.containsAll(ontologyMetricsDimensions)) {
             List<String> semanticFields = Lists.newArrayList();
             ontologyQuery.getMetrics().forEach(m -> semanticFields.add(m.getName()));
             ontologyQuery.getDimensions().forEach(d -> semanticFields.add(d.getName()));


### PR DESCRIPTION
一、 修复生成的SQL字段不在数据集内，导致查询异常的问题，由原来的字段数量判断更改为查询字段是否包含维度和度量字段
#2007
二、 修复开启多轮对话会使用默认的gpt-4o-mini账号去进行过程检测而不是使用配置好的本地大模型的问题
#2251
问题说明：
1、问题一中的原有方法中是根据查询字段数量是否大于维度+度量的字段数量来判断是否包含不匹配的字段，这样即使text2sql是对的，因大模型自己新增了1个或多个字段也会报错，很影响体验。现更改为查询字段是否包含维度+度量的字段来判断是否包含不匹配的字段。如大模型自行新增字段，可通过修改提示词模板来约束新增字段问题。