### PR TITLE
(fix)(supersonic-fe)Fix the issues of repeated and missing field displays in semantic modeling

### DIFF
--- a/webapp/packages/supersonic-fe/src/pages/SemanticModel/Datasource/components/ModelCreateForm.tsx
+++ b/webapp/packages/supersonic-fe/src/pages/SemanticModel/Datasource/components/ModelCreateForm.tsx
@@ -299,21 +299,22 @@ const ModelCreateForm: React.FC<CreateFormProps> = ({
       return;
     }
 
-    const columnFields: any[] = columns.map((item: IDataSource.IExecuteSqlColumn) => {
+    const fieldMap = new Map(
+      fieldsClassifyList.map(field => [field.fieldName, field])
+    );
+    columns.forEach((item: IDataSource.IExecuteSqlColumn) => {
       const { type, nameEn, comment } = item;
-      const oldItem =
-        fieldsClassifyList.find((oItem) => {
-          return oItem.fieldName === item.nameEn;
-        }) || {};
-      return {
-        ...oldItem,
+      const existingField = fieldMap.get(nameEn);
+
+      fieldMap.set(nameEn, {
+        ...existingField,
         bizName: nameEn,
         fieldName: nameEn,
         dataType: type,
         comment,
-      };
+      });
     });
-    setFields(columnFields || []);
+    setFields(Array.from(fieldMap.values()));
   };
 
   const formatterIdentifiers = (identifiersList: any[] = []) => {


### PR DESCRIPTION
# Pull Request Template

## Description

Fix the issues of duplicate and disappearing field displays in semantic modeling

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.           Provide instructions so we can reproduce.            Please also list any relevant details for your test configuration.

- [] Manually test according to the page display
- [] build test, build deployment test

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## Additional information
When there are a large number of Fields and there are duplicate Fields in the columns, the map traversal and merge the field data will fail and add duplicate data to the fields, resulting in the bizName field in the fields being duplicated. However, the rowkey displayed in the table is bound to the bizName. The rendering display issue is caused by key duplication

Fixes #2253