### PR TITLE
when sql script has variables, generate sql can't be executed, this commit  supports variable replement

### DIFF
--- a/headless/api/src/main/java/com/tencent/supersonic/headless/api/pojo/SqlVariable.java
+++ b/headless/api/src/main/java/com/tencent/supersonic/headless/api/pojo/SqlVariable.java
@@ -2,11 +2,17 @@ package com.tencent.supersonic.headless.api.pojo;
 
 import com.google.common.collect.Lists;
 import com.tencent.supersonic.headless.api.pojo.enums.VariableValueType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class SqlVariable {
     private String name;
     private VariableValueType valueType;

--- a/headless/core/src/main/java/com/tencent/supersonic/headless/core/translator/parser/calcite/DataModelNode.java
+++ b/headless/core/src/main/java/com/tencent/supersonic/headless/core/translator/parser/calcite/DataModelNode.java
@@ -14,6 +14,7 @@ import com.tencent.supersonic.headless.core.pojo.JoinRelation;
 import com.tencent.supersonic.headless.core.pojo.Ontology;
 import com.tencent.supersonic.headless.core.pojo.OntologyQuery;
 import com.tencent.supersonic.headless.core.translator.parser.Constants;
+import com.tencent.supersonic.headless.core.utils.SqlVariableParseUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.calcite.sql.SqlDataTypeSpec;
 import org.apache.calcite.sql.SqlNode;
@@ -34,6 +35,10 @@ public class DataModelNode extends SemanticNode {
         if (dataModel.getModelDetail().getSqlQuery() != null
                 && !dataModel.getModelDetail().getSqlQuery().isEmpty()) {
             sqlTable = dataModel.getModelDetail().getSqlQuery();
+            // if model has sqlVariables, parse sqlVariables
+            if (Objects.nonNull(dataModel.getModelDetail().getSqlVariables()) || (CollectionUtils.isEmpty(dataModel.getModelDetail().getSqlVariables()))) {
+                sqlTable = SqlVariableParseUtils.parse(sqlTable, dataModel.getModelDetail().getSqlVariables(), Lists.newArrayList());
+            }
         } else if (dataModel.getModelDetail().getTableQuery() != null
                 && !dataModel.getModelDetail().getTableQuery().isEmpty()) {
             if (dataModel.getModelDetail().getDbType()

--- a/headless/server/src/main/java/com/tencent/supersonic/headless/server/manager/ModelYamlManager.java
+++ b/headless/server/src/main/java/com/tencent/supersonic/headless/server/manager/ModelYamlManager.java
@@ -39,6 +39,7 @@ public class ModelYamlManager {
         dataModelYamlTpl.setFilterSql(modelDetail.getFilterSql());
         dataModelYamlTpl.setFields(modelResp.getModelDetail().getFields());
         dataModelYamlTpl.setId(modelResp.getId());
+        dataModelYamlTpl.setSqlVariables(modelDetail.getSqlVariables());
         return dataModelYamlTpl;
     }
 

--- a/headless/server/src/main/java/com/tencent/supersonic/headless/server/manager/SemanticSchemaManager.java
+++ b/headless/server/src/main/java/com/tencent/supersonic/headless/server/manager/SemanticSchemaManager.java
@@ -102,7 +102,7 @@ public class SemanticSchemaManager {
         modelDetail.getMeasures().addAll(getMeasureParams(d.getMeasures()));
         modelDetail.getDimensions().addAll(getDimensions(d.getDimensions()));
         modelDetail.getFields().addAll(d.getFields());
-
+        modelDetail.getSqlVariables().addAll(d.getSqlVariables());
         return dataModel;
     }
 

--- a/headless/server/src/main/java/com/tencent/supersonic/headless/server/pojo/StarrocksParametersBuilder.java
+++ b/headless/server/src/main/java/com/tencent/supersonic/headless/server/pojo/StarrocksParametersBuilder.java
@@ -15,7 +15,7 @@ public class StarrocksParametersBuilder extends DefaultParametersBuilder {
         List<DatabaseParameter> databaseParameters = new ArrayList<>();
         DatabaseParameter host = new DatabaseParameter();
         host.setComment("JDBC连接");
-        host.setValue("jdbc:mysql://localhost:3306/dbname");
+        host.setValue("jdbc:mysql://localhost:9030/dbname");
         host.setName("url");
         host.setPlaceholder("请输入JDBC连接串");
         databaseParameters.add(host);

--- a/headless/server/src/main/java/com/tencent/supersonic/headless/server/pojo/yaml/DataModelYamlTpl.java
+++ b/headless/server/src/main/java/com/tencent/supersonic/headless/server/pojo/yaml/DataModelYamlTpl.java
@@ -1,6 +1,7 @@
 package com.tencent.supersonic.headless.server.pojo.yaml;
 
 import com.tencent.supersonic.headless.api.pojo.Field;
+import com.tencent.supersonic.headless.api.pojo.SqlVariable;
 import com.tencent.supersonic.headless.api.pojo.enums.ModelSourceType;
 import lombok.Data;
 
@@ -32,4 +33,6 @@ public class DataModelYamlTpl {
     private List<Field> fields;
 
     private ModelSourceType modelSourceTypeEnum;
+
+    private List<SqlVariable> sqlVariables;
 }


### PR DESCRIPTION
# Pull Request Template

## Description

when sql script has variables, generate sql can't be executed, this commit  supports variable replement

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings

## Additional information

Any additional information, configuration or data that might be necessary to reproduce the issue.
[Bug] 语义建模-模型管理中选择sql编辑，添加动态变量提供默认值(https://github.com/tencentmusic/supersonic/issues/2258) 
fixed #2258 