### PR TITLE
(fix)(chat)Fixed level 2 drilldown dimension error

### DIFF
--- a/webapp/packages/chat-sdk/src/components/ChatMsg/index.tsx
+++ b/webapp/packages/chat-sdk/src/components/ChatMsg/index.tsx
@@ -293,7 +293,7 @@ const ChatMsg: React.FC<Props> = ({
       dateInfo: {
         ...chatContext.dateInfo,
         dateMode: dateModeValue,
-        unit: currentDateOption || chatContext.dateInfo.unit,
+        unit: currentDateOption || chatContext.dateInfo?.unit,
       },
       dimensions: [
         ...(chatContext.dimensions || []),
@@ -310,7 +310,7 @@ const ChatMsg: React.FC<Props> = ({
       dateInfo: {
         ...chatContext.dateInfo,
         dateMode: dateModeValue,
-        unit: currentDateOption || chatContext.dateInfo.unit,
+        unit: currentDateOption || chatContext.dateInfo?.unit,
       },
       dimensions: drillDownDimension
         ? [...(chatContext.dimensions || []), drillDownDimension]


### PR DESCRIPTION
# Pull Request Template

## Description

When using a drill-down dimension, clicking on the select Level 2 drill-down dimension will cause an error

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation

## Additional information

Any additional information, configuration or data that might be necessary to reproduce the issue.


fixed #2271 