### PR TITLE
(fix)(chat) 修复插件功能，无法调用/插件结果被NL2SQL结果覆盖的问题

### DIFF
--- a/chat/server/src/main/java/com/tencent/supersonic/chat/server/parser/NL2PluginParser.java
+++ b/chat/server/src/main/java/com/tencent/supersonic/chat/server/parser/NL2PluginParser.java
@@ -22,9 +22,6 @@ public class NL2PluginParser implements ChatQueryParser {
     public void parse(ParseContext parseContext) {
         pluginRecognizers.forEach(pluginRecognizer -> {
             pluginRecognizer.recognize(parseContext);
-            if (parseContext.getResponse().getSelectedParses().size()>=2){
-                parseContext.getResponse().setSelectedParses(parseContext.getResponse().getSelectedParses().subList(0, 1));
-            }
             log.info("{} recallResult:{}", pluginRecognizer.getClass().getSimpleName(),
                     JsonUtil.toString(parseContext.getResponse()));
         });

--- a/chat/server/src/main/java/com/tencent/supersonic/chat/server/parser/NL2PluginParser.java
+++ b/chat/server/src/main/java/com/tencent/supersonic/chat/server/parser/NL2PluginParser.java
@@ -22,6 +22,9 @@ public class NL2PluginParser implements ChatQueryParser {
     public void parse(ParseContext parseContext) {
         pluginRecognizers.forEach(pluginRecognizer -> {
             pluginRecognizer.recognize(parseContext);
+            if (parseContext.getResponse().getSelectedParses().size()>=2){
+                parseContext.getResponse().setSelectedParses(parseContext.getResponse().getSelectedParses().subList(0, 1));
+            }
             log.info("{} recallResult:{}", pluginRecognizer.getClass().getSimpleName(),
                     JsonUtil.toString(parseContext.getResponse()));
         });

--- a/chat/server/src/main/java/com/tencent/supersonic/chat/server/plugin/build/webservice/WebServiceQuery.java
+++ b/chat/server/src/main/java/com/tencent/supersonic/chat/server/plugin/build/webservice/WebServiceQuery.java
@@ -88,10 +88,10 @@ public class WebServiceQuery extends PluginSemanticQuery {
         restTemplate = ContextUtils.getBean(RestTemplate.class);
         try {
             responseEntity =
-                    restTemplate.exchange(requestUrl, HttpMethod.POST, entity, Object.class);
+                    restTemplate.exchange(requestUrl, HttpMethod.POST, entity, String.class);
             objectResponse = responseEntity.getBody();
             log.info("objectResponse:{}", objectResponse);
-            Map<String, Object> response = JsonUtil.objectToMap(objectResponse);
+            Map<String, Object> response = Json.parseObject(objectResponse.toString());
             webServiceResponse.setResult(response);
         } catch (Exception e) {
             log.info("Exception:{}", e.getMessage());

--- a/chat/server/src/main/java/com/tencent/supersonic/chat/server/plugin/build/webservice/WebServiceQuery.java
+++ b/chat/server/src/main/java/com/tencent/supersonic/chat/server/plugin/build/webservice/WebServiceQuery.java
@@ -91,7 +91,7 @@ public class WebServiceQuery extends PluginSemanticQuery {
                     restTemplate.exchange(requestUrl, HttpMethod.POST, entity, String.class);
             objectResponse = responseEntity.getBody();
             log.info("objectResponse:{}", objectResponse);
-            Map<String, Object> response = Json.parseObject(objectResponse.toString());
+            Map<String, Object> response = JSON.parseObject(objectResponse.toString());
             webServiceResponse.setResult(response);
         } catch (Exception e) {
             log.info("Exception:{}", e.getMessage());

--- a/chat/server/src/main/java/com/tencent/supersonic/chat/server/pojo/ParseContext.java
+++ b/chat/server/src/main/java/com/tencent/supersonic/chat/server/pojo/ParseContext.java
@@ -19,7 +19,7 @@ public class ParseContext {
     }
 
     public boolean enableNL2SQL() {
-        return Objects.nonNull(agent) && agent.containsDatasetTool();
+        return Objects.nonNull(agent) && agent.containsDatasetTool()&&response.getSelectedParses().size() == 0;
     }
 
     public boolean enableLLM() {


### PR DESCRIPTION
1、修改WebServiceQuery，将返回体解析类由Object.class改为String.class。否则会报：Error while extracting response for type [class java.lang.Object] and content type [application/xml;charset=UTF-8]错误
2、使用fastjson解析response，原有方法会报错
3、修改ParseContext，将是否需要进行NL2SQL的判断新增了对response中SelectedParses的判断，如果有值，说明插件已召回，不需要进行NL2SQL了，否则NL2SQL的结果会覆盖掉Plugin的结果
#2206 
#2165 