### PR TITLE
(fix)(supersonic-fe) correct 'catalog' parameter in table column query

### DIFF
--- a/webapp/packages/supersonic-fe/src/pages/SemanticModel/Datasource/components/ModelCreateForm.tsx
+++ b/webapp/packages/supersonic-fe/src/pages/SemanticModel/Datasource/components/ModelCreateForm.tsx
@@ -363,7 +363,7 @@ const ModelCreateForm: React.FC<CreateFormProps> = ({
       }
       if (tableQueryString.split('.').length === 2) {
         const [dbName, tableName] = tableQueryString.split('.');
-        columns = await queryTableColumnList(modelItem.databaseId, '', dbName, tableName);
+        columns = await queryTableColumnList(modelItem.databaseId, dbName, dbName, tableName);
         tableQueryInitValue = {
           catalog: '',
           dbName,


### PR DESCRIPTION
## Description

When querying table columns for MySQL databases, the `queryTableColumnList` method was passing an empty string as the catalog parameter, causing `DatabaseMetaData.getColumns()` to return columns from all databases instead of the specified database only.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules