### PR TITLE
(fix)(headless) use database name as catalog when catalog is empty

### DIFF
--- a/headless/server/src/main/java/com/tencent/supersonic/headless/server/service/impl/DatabaseServiceImpl.java
+++ b/headless/server/src/main/java/com/tencent/supersonic/headless/server/service/impl/DatabaseServiceImpl.java
@@ -282,6 +282,7 @@ public class DatabaseServiceImpl extends ServiceImpl<DatabaseDOMapper, DatabaseD
     public List<DBColumn> getColumns(Long id, String catalog, String db, String table)
             throws SQLException {
         DatabaseResp databaseResp = getDatabase(id);
+        catalog = StringUtils.isEmpty(catalog) ? db : catalog;
         return getColumns(databaseResp, catalog, db, table);
     }
 


### PR DESCRIPTION
## Description

When querying table columns through `getColumns()` method, if the catalog parameter is empty, MySQL JDBC driver's `DatabaseMetaData.getColumns()` method queries all databases instead of the target database, returning columns from tables with the same name across different databases.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules