### PR TITLE
[fix](standalone): spelling errors in the last_login field of the s2_user table

### DIFF
--- a/launchers/standalone/src/main/resources/config.update/sql-update-mysql.sql
+++ b/launchers/standalone/src/main/resources/config.update/sql-update-mysql.sql
@@ -420,4 +420,4 @@ ALTER TABLE s2_chat_model add column is_open tinyint DEFAULT NULL COMMENT '是�
 ALTER TABLE s2_database add column is_open tinyint DEFAULT NULL COMMENT '是否公开';
 
 --20250321
-ALTER TABLE s2_user add column last_loin datetime DEFAULT NULL;
+ALTER TABLE s2_user add column last_login datetime DEFAULT NULL;


### PR DESCRIPTION
Correct the name of the last_loin field in the s2_user table to last_login

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Also include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional information

Any additional information, configuration or data that might be necessary to reproduce the issue.