### PR TITLE
(fix)(chat-sdk) rm table defaultSortOrder

### DIFF
--- a/webapp/packages/chat-sdk/src/components/ChatMsg/Table/index.tsx
+++ b/webapp/packages/chat-sdk/src/components/ChatMsg/Table/index.tsx
@@ -24,7 +24,6 @@ const Table: React.FC<Props> = ({ data, size, loading, question, onApplyAuth }) 
         dataIndex: bizName,
         key: bizName,
         title: name || bizName,
-        defaultSortOrder: 'descend',
         sorter:
           showType === 'NUMBER'
             ? (a, b) => {
@@ -73,10 +72,11 @@ const Table: React.FC<Props> = ({ data, size, loading, question, onApplyAuth }) 
     return index % 2 !== 0 ? `${prefixCls}-even-row` : '';
   };
 
-  const dateColumn = queryColumns.find(column => column.type === 'DATE');
+  const dateColumn = queryColumns.find(column => column.type === 'DATE' || column.showType === 'DATE');
   const dataSource = dateColumn
     ? queryResults.sort((a, b) => moment(a[dateColumn.bizName]).diff(moment(b[dateColumn.bizName])))
     : queryResults;
+
   return (
     <div className={prefixCls}>
       {question && (


### PR DESCRIPTION
# Pull Request Template

## Description

1. Table 不需要设置 defaultSortOrder，因为 dataSource 的顺序是不确定的，同时也会受到是否有 dateColumn 的影响；
2. 统一一下 dateColumn 的查询条件

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Empty

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings