### PR TITLE
(fix)(chat-sdk): Export data based on queryColumns

### DIFF
--- a/webapp/packages/chat-sdk/src/components/ChatItem/index.tsx
+++ b/webapp/packages/chat-sdk/src/components/ChatItem/index.tsx
@@ -416,11 +416,10 @@ const ChatItem: React.FC<Props> = ({
 
   const onExportData = () => {
     const { queryColumns, queryResults } = data || {};
-    if (!!queryResults) {
+    if (!!queryResults && !!queryColumns) {
       const exportData = queryResults.map(item => {
-        return Object.keys(item).reduce((result, key) => {
-          const columnName = queryColumns?.find(column => column.nameEn === key)?.name || key;
-          result[columnName] = item[key];
+        return queryColumns.reduce((result, column) => {
+          result[column.name || column.nameEn] = item[column.nameEn];
           return result;
         }, {});
       });


### PR DESCRIPTION
# Pull Request Template

## Description

一般来说，queryColumns 和 queryResults 中的属性应该是一一对应的；
但如果出现下面的情况，会导致导出的 csv 文件缺少一列：

```json
{
    "queryColumns": [
        {
            "name": "date",
            "type": "VARCHAR",
            "nameEn": "sys_imp_date",
            "showType": "DATE",
            "authorized": true,
            "dataFormatType": null,
            "dataFormat": null,
            "comment": null
        },
        {
            "name": "部门",
            "type": "VARCHAR",
            "nameEn": "department",
            "showType": "CATEGORY",
            "authorized": true,
            "dataFormatType": null,
            "dataFormat": null,
            "comment": null
        },
        {
            "name": "访问次数",
            "type": "BIGINT",
            "nameEn": "访问次数",
            "showType": "NUMBER",
            "authorized": true,
            "dataFormatType": null,
            "dataFormat": null,
            "comment": null
        }
    ],
    "queryResults": [
        {
            "sys_imp_date": "2025-06-11",
            "department": "sales"
        },
        {
            "sys_imp_date": "2025-06-10",
            "department": "sales"
        }
    ]
}
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings