### PR TITLE
(fix)(headless) preserve model join order by using LinkedHashSet in probeRelatedModels

### DIFF
--- a/headless/core/src/main/java/com/tencent/supersonic/headless/core/translator/parser/calcite/SqlBuilder.java
+++ b/headless/core/src/main/java/com/tencent/supersonic/headless/core/translator/parser/calcite/SqlBuilder.java
@@ -88,7 +88,7 @@ public class SqlBuilder {
         GraphPath<String, DefaultEdge> selectedGraphPath = null;
         for (String fromModel : queryModels) {
             for (String toModel : queryModels) {
-                if (fromModel != toModel) {
+                if (!fromModel.equals(toModel)) {
                     GraphPath<String, DefaultEdge> path = dijkstraAlg.getPath(fromModel, toModel);
                     if (isGraphPathContainsAll(path, queryModels)) {
                         selectedGraphPath = path;
@@ -100,13 +100,13 @@ public class SqlBuilder {
         if (selectedGraphPath == null) {
             return dataModels;
         }
-        Set<String> modelNames = Sets.newHashSet();
+        Set<String> modelNames = Sets.newLinkedHashSet();
         for (DefaultEdge edge : selectedGraphPath.getEdgeList()) {
             modelNames.add(selectedGraphPath.getGraph().getEdgeSource(edge));
             modelNames.add(selectedGraphPath.getGraph().getEdgeTarget(edge));
         }
         return modelNames.stream().map(m -> ontology.getModelMap().get(m))
-                .collect(Collectors.toSet());
+                .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     private boolean isGraphPathContainsAll(GraphPath<String, DefaultEdge> graphPath,


### PR DESCRIPTION
## Description

The current implementation uses HashSet to collect model names from the shortest path, which loses the order of models in the join path. This can lead to incorrect SQL JOIN sequences being generated.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules