### PR TITLE
(fix)(headless) add empty check for metric alias to prevent incorrect DataFormatType assignment

### DIFF
--- a/headless/server/src/main/java/com/tencent/supersonic/headless/server/utils/QueryUtils.java
+++ b/headless/server/src/main/java/com/tencent/supersonic/headless/server/utils/QueryUtils.java
@@ -109,7 +109,7 @@ public class QueryUtils {
                     column.setModelId(metric.getModelId());
                 }
                 // if column nameEn contains metric alias, use metric dataFormatType
-                if (column.getDataFormatType() == null && metric.getAlias() != null) {
+                if (column.getDataFormatType() == null && StringUtils.isNotEmpty(metric.getAlias())) {
                     for (String alias : metric.getAlias().split(",")) {
                         if (nameEn.contains(alias)) {
                             column.setDataFormatType(metric.getDataFormatType());


### PR DESCRIPTION
## Description

When manually adding metrics or removing aliases from existing metrics, the `alias` field can be an empty string (`""`) instead of `null`. The current code only checks for null but not empty strings, leading to:
- Incorrect DataFormatType assignment: `nameEn.contains("")` always returns `true`

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules