### PR TITLE
(fix | improvement) fix the aliases obtained by intelligent recognition could not be converted in Q&A. modify to allow all LLMs to be called on LLM management page

### DIFF
--- a/common/src/main/java/com/tencent/supersonic/common/config/AliasGenerateParameterConfig.java
+++ b/common/src/main/java/com/tencent/supersonic/common/config/AliasGenerateParameterConfig.java
@@ -1,0 +1,38 @@
+package com.tencent.supersonic.common.config;
+
+import com.google.common.collect.Lists;
+import com.tencent.supersonic.common.pojo.Parameter;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service("AliasGenerateParameterConfig")
+public class AliasGenerateParameterConfig extends ParameterConfig {
+    private static final String MODULE_NAME = "智能填充配置";
+
+    public static final Parameter LLM_ALIAS_GENERATION_MODEL =
+            new Parameter("llm.alias.generation.model", "1",
+                    "别名生成选用模型", "用于指标、维度等别名生成", "string", MODULE_NAME);
+
+    public static final String ALIAS_GENERATE_TUTORIAL = 
+            "#Role: You are a professional data analyst specializing in metrics and dimensions.\n"
+            + "#Task: You will be provided with metadata about a metric or dimension, please help "
+            + "generate a few aliases in the same language as its name.\n"
+            + "#Rules:\n"
+            + "1. Please do not generate aliases like xxx1, xxx2, xxx3.\n"
+            + "2. Please do not generate aliases that are the same as the original names of metrics/dimensions.\n"
+            + "3. Please pay attention to the quality of the generated aliases and "
+            + "avoid creating aliases that look like test data.\n"
+            + "4. Please output as a json string array.\n"
+            + "#Output:";
+
+    public static final Parameter LLM_ALIAS_GENERATION_PROMPT =
+            new Parameter("llm.alias.generation.prompt", ALIAS_GENERATE_TUTORIAL,
+                    "别名生成Prompt", "用于指标、维度等别名生成的Prompt", "longText", MODULE_NAME);
+
+    @Override
+    public List<Parameter> getSysParameters() {
+        return Lists.newArrayList(LLM_ALIAS_GENERATION_MODEL, LLM_ALIAS_GENERATION_PROMPT);
+    }
+} 
+ 

--- a/common/src/main/java/com/tencent/supersonic/common/config/SystemConfig.java
+++ b/common/src/main/java/com/tencent/supersonic/common/config/SystemConfig.java
@@ -74,4 +74,8 @@ public class SystemConfig {
         }
         return defaultParameters;
     }
+
+    public String getAliasGeneratePrompt() {
+        return getParameterByName(AliasGenerateParameterConfig.LLM_ALIAS_GENERATION_PROMPT.getName());
+    }
 }

--- a/headless/chat/src/main/java/com/tencent/supersonic/headless/chat/corrector/LLMPhysicalSqlCorrector.java
+++ b/headless/chat/src/main/java/com/tencent/supersonic/headless/chat/corrector/LLMPhysicalSqlCorrector.java
@@ -71,6 +71,12 @@ public class LLMPhysicalSqlCorrector extends BaseSemanticCorrector {
             return;
         }
 
+        // Check if querySQL is null to avoid template variable error
+        String querySQL = semanticParseInfo.getSqlInfo().getQuerySQL();
+        if (StringUtils.isBlank(querySQL)) {
+            return;
+        }
+
         ChatLanguageModel chatLanguageModel =
                 ModelProvider.getChatModel(chatApp.getChatModelConfig());
         PhysicalSqlExtractor extractor =

--- a/headless/server/src/main/java/com/tencent/supersonic/headless/server/service/impl/MetricServiceImpl.java
+++ b/headless/server/src/main/java/com/tencent/supersonic/headless/server/service/impl/MetricServiceImpl.java
@@ -473,12 +473,16 @@ public class MetricServiceImpl extends ServiceImpl<MetricDOMapper, MetricDO>
 
     @Override
     public List<String> mockAlias(MetricBaseReq metricReq, String mockType, User user) {
-
-        String mockAlias = aliasGenerateHelper.generateAlias(mockType, metricReq.getName(),
-                metricReq.getBizName(), "", metricReq.getDescription());
-        String ret = mockAlias.replaceAll("`", "").replace("json", "").replace("\n", "")
-                .replace(" ", "");
-        return JSONObject.parseObject(ret, new TypeReference<List<String>>() {});
+        String name = metricReq.getName();
+        ModelResp modelResp = modelService.getModel(metricReq.getModelId());
+        if (Objects.isNull(modelResp)) {
+            return Lists.newArrayList();
+        }
+        String modelName = modelResp.getName();
+        if (StringUtils.isBlank(name) || StringUtils.isBlank(modelName)) {
+            return Lists.newArrayList();
+        }
+        return aliasGenerateHelper.generateAlias(modelName, name, "metric");
     }
 
     @Override

--- a/headless/server/src/main/java/com/tencent/supersonic/headless/server/utils/AliasGenerateHelper.java
+++ b/headless/server/src/main/java/com/tencent/supersonic/headless/server/utils/AliasGenerateHelper.java
@@ -2,86 +2,185 @@ package com.tencent.supersonic.headless.server.utils;
 
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONException;
-import dev.langchain4j.data.message.AiMessage;
-import dev.langchain4j.data.message.SystemMessage;
+import com.alibaba.fastjson.TypeReference;
+import com.google.common.collect.Lists;
+import com.tencent.supersonic.common.service.SystemConfigService;
+import com.tencent.supersonic.common.util.ContextUtils;
+import com.tencent.supersonic.headless.server.service.ModelService;
 import dev.langchain4j.model.chat.ChatLanguageModel;
-import dev.langchain4j.model.input.Prompt;
-import dev.langchain4j.model.input.PromptTemplate;
-import dev.langchain4j.model.output.Response;
 import dev.langchain4j.provider.ModelProvider;
-import lombok.extern.slf4j.Slf4j;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Component;
-
-import java.util.HashMap;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
 public class AliasGenerateHelper {
 
-    private static final Logger keyPipelineLog = LoggerFactory.getLogger("keyPipeline");
-
-    private static final String NAME_ALIAS_INSTRUCTION = ""
-            + "#Role: You are a professional data analyst specializing in metrics and dimensions."
-            + "\n#Task: You will be provided with metadata about a metric or dimension, please help "
-            + "generate a few aliases in the same language as its `fieldName`." + "\n#Rules:"
-            + "1. Please do not generate aliases like xxx1, xxx2, xxx3."
-            + "2. Please do not generate aliases that are the same as the original names of metrics/dimensions."
-            + "3. Please pay attention to the quality of the generated aliases and "
-            + "avoid creating aliases that look like test data."
-            + "4. Please output as a json string array."
-            + "\n#Metadata: {'table':'{{table}}', 'name':'{{name}}', 'type':'{{type}}', "
-            + "'field':'field', 'description':'{{desc}}'}" + "\n#Output:";
+    private static final int MAX_RETRIES = 3;
+    private static final String ALIAS_GENERATE_FILTER_INSTRUCTION =
+            "Based on the following information, your task is to select the most suitable aliases for the given element name from the candidate aliases provided. "
+                    + "Please output the results as a comma-separated list.";
 
     private static final String VALUE_ALIAS_INSTRUCTION =
             "" + "\n#Role: You are a professional data analyst."
                     + "\n#Task: You will be provided with a json array of dimension values,"
                     + "please help generate a few aliases for each value." + "\n#Rule:"
-                    + "1. ALWAYS output json array for each value."
+                    + "1. ALWAYS output json object for each value."
                     + "2. The aliases should be in the same language as its original value."
-                    + "\n#Exemplar:" + "Values: [\\\"qq_music\\\",\\\"kugou_music\\\"], "
-                    + "Output: {\\\"tran\\\":[\\\"qq音乐\\\",\\\"酷狗音乐\\\"],"
-                    + "         \\\"alias\\\":{\\\"qq_music\\\":[\\\"q音\\\",\\\"qq音乐\\\"],"
-                    + "         \\\"kugou_music\\\":[\\\"kugou\\\",\\\"酷狗\\\"]}}"
-                    + "\nValues: {{values}}, Output:";
+                    + "\n#Exemplar:" + "Values: [\"qq_music\",\"kugou_music\"], "
+                    + "Output: {\"tran\":[\"qq音乐\",\"酷狗音乐\"],"
+                    + "         \"alias\":{\"qq_music\":[\"q音\",\"qq音乐\"],"
+                    + "         \"kugou_music\":[\"kugou\",\"酷狗\"]}}"
+                    + "\nValues: %s, Output:";
 
-    public String generateAlias(String mockType, String name, String bizName, String table,
-            String desc) {
-        Map<String, Object> variable = new HashMap<>();
-        variable.put("table", table);
-        variable.put("name", name);
-        variable.put("field", bizName);
-        variable.put("type", mockType);
-        variable.put("desc", desc);
+    @Autowired
+    private ModelService modelService;
 
-        Prompt prompt = PromptTemplate.from(NAME_ALIAS_INSTRUCTION).apply(variable);
-        String response = getChatCompletion(prompt);
-        keyPipelineLog.info("AliasGenerateHelper.generateAlias modelReq:\n{} \nmodelResp:\n{}",
-                prompt.text(), response);
-        return response;
+    public List<String> generateAlias(String modelName, String elementName, String elementType) {
+        String prompt = generatePrompt(modelName, elementName, elementType);
+        String llmResult = doGenerateRaw(prompt);
+        if (StringUtils.isBlank(llmResult)) {
+            return Lists.newArrayList();
+        }
+        try {
+            String jsonContent = extractJsonStringFromAiMessage(llmResult);
+            log.info("Extracted JSON content: {}", jsonContent);
+            
+            // Try to parse as simple JSON array first (expected format)
+            try {
+                List<String> aliases = JSON.parseObject(jsonContent, new TypeReference<List<String>>() {});
+                log.info("Found aliases for element '{}': {}", elementName, aliases);
+                return aliases;
+            } catch (Exception e1) {
+                // If that fails, try to parse as complex JSON object (fallback)
+                Map<String, Object> jsonMap = JSON.parseObject(jsonContent, Map.class);
+                
+                // Try to find alias map from different possible field names
+                Map<String, List<String>> aliasMap = null;
+                if (jsonMap.containsKey("alias")) {
+                    aliasMap = (Map<String, List<String>>) jsonMap.get("alias");
+                }
+                
+                if (aliasMap != null && aliasMap.containsKey(elementName)) {
+                    List<String> aliases = aliasMap.get(elementName);
+                    log.info("Found aliases for element '{}': {}", elementName, aliases);
+                    return aliases;
+                } else {
+                    log.warn("No aliases found for element '{}' in alias map: {}", elementName, aliasMap);
+                    return Lists.newArrayList();
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Failed to parse alias json from LLM result, try to split by comma, llmResult:{}, error: {}", llmResult, e.getMessage());
+            return Arrays.stream(llmResult.split(","))
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty())
+                    .collect(Collectors.toList());
+        }
+    }
+
+    public List<String> filterAlias(String modelName, String elementName, String elementType,
+            List<String> candidateAlias) {
+        String prompt = generateFilterPrompt(modelName, elementName, elementType, candidateAlias);
+        String llmResult = doGenerateRaw(prompt);
+        if (StringUtils.isBlank(llmResult)) {
+            return Lists.newArrayList();
+        }
+        return Arrays.stream(llmResult.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toList());
     }
 
     public String generateDimensionValueAlias(String json) {
-        Map<String, Object> variable = new HashMap<>();
-        variable.put("values", json);
-
-        Prompt prompt = PromptTemplate.from(VALUE_ALIAS_INSTRUCTION).apply(variable);
-        String response = getChatCompletion(prompt);
-        keyPipelineLog.info(
-                "AliasGenerateHelper.generateValueAlias modelReq:\n{} " + "\nmodelResp:\n{}",
-                prompt.text(), response);
-
-
-        return response;
+        String prompt = String.format(VALUE_ALIAS_INSTRUCTION, json);
+        return doGenerateRaw(prompt);
     }
 
-    private String getChatCompletion(Prompt prompt) {
-        SystemMessage from = prompt.toSystemMessage();
+    private String doGenerateRaw(String prompt) {
+        log.info("doGenerate, prompt:{}", prompt);
         ChatLanguageModel chatLanguageModel = ModelProvider.getChatModel();
-        Response<AiMessage> response = chatLanguageModel.generate(from);
-        return response.content().text();
+        if (chatLanguageModel == null) {
+            return "";
+        }
+        int maxRetries = 0;
+        String llmResult = "";
+        while (maxRetries < MAX_RETRIES) {
+            try {
+                llmResult = chatLanguageModel.generate(prompt);
+                break;
+            } catch (Exception e) {
+                log.error("llmResult is empty, maxRetries:{}", maxRetries, e);
+                maxRetries++;
+                try {
+                    TimeUnit.MILLISECONDS.sleep(100);
+                } catch (InterruptedException ex) {
+                    throw new RuntimeException(ex);
+                }
+            }
+        }
+        log.info("llmResult:{}", llmResult);
+        return llmResult;
+    }
+
+    private String generatePrompt(String modelName, String elementName, String elementType) {
+        SystemConfigService systemConfigService = ContextUtils.getBean(SystemConfigService.class);
+        String promptTemplate = systemConfigService.getSystemConfig().getAliasGeneratePrompt();
+        String requirement = String.format("model name is %s, %s name is %s", modelName, elementType, elementName);
+        return promptTemplate + "\n" + requirement;
+    }
+
+    private String generateFilterPrompt(String modelName, String elementName, String elementType,
+            List<String> candidateAlias) {
+        String requirement = String.format("model name is %s, %s name is %s, candidate aliases are %s",
+                modelName, elementType, elementName, String.join(",", candidateAlias));
+        return ALIAS_GENERATE_FILTER_INSTRUCTION + "\n" + requirement;
+    }
+
+    public static String extractJsonStringFromAiMessage(String aiMessage) {
+        class BoundaryPattern {
+            final String left;
+            final String right;
+            final Boolean exclusionFlag;
+
+            public BoundaryPattern(String start, String end, Boolean includeMarkers) {
+                this.left = start;
+                this.right = end;
+                this.exclusionFlag = includeMarkers;
+            }
+        }
+        BoundaryPattern[] patterns = {
+                new BoundaryPattern(null, null, null),
+                new BoundaryPattern("```", "```", true),
+                new BoundaryPattern("```json", "```", true),
+                new BoundaryPattern("```JSON", "```", true),
+                new BoundaryPattern("{", "}", false),
+                new BoundaryPattern("[", "]", false)};
+        for (BoundaryPattern pattern : patterns) {
+            String extracted =
+                    extractString(aiMessage, pattern.left, pattern.right, pattern.exclusionFlag);
+            if (extracted == null) {
+                continue;
+            }
+            try {
+                JSON.parseObject(extracted);
+                return extracted;
+            } catch (JSONException ignored) {
+            }
+            try {
+                JSON.parseArray(extracted);
+                return extracted;
+            } catch (JSONException ignored) {
+            }
+        }
+        throw new JSONException("json extract failed");
     }
 
     private static String extractString(String targetString, String left, String right,
@@ -120,53 +219,5 @@ public class AliasGenerateHelper {
             }
             return extractedString;
         }
-    }
-
-    public static String extractJsonStringFromAiMessage(String aiMessage) {
-        class BoundaryPattern {
-            final String left;
-            final String right;
-            final Boolean exclusionFlag;
-
-            public BoundaryPattern(String start, String end, Boolean includeMarkers) {
-                this.left = start;
-                this.right = end;
-                this.exclusionFlag = includeMarkers;
-            }
-        }
-        BoundaryPattern[] patterns = {
-                        // 不做任何匹配
-                        new BoundaryPattern(null, null, null),
-                        // ```{"name":"Alice","age":25,"city":"NewYork"}```
-                        new BoundaryPattern("```", "```", true),
-                        // ```json {"name":"Alice","age":25,"city":"NewYork"}```
-                        new BoundaryPattern("```json", "```", true),
-                        // ```JSON {"name":"Alice","age":25,"city":"NewYork"}```
-                        new BoundaryPattern("```JSON", "```", true),
-                        // {"name":"Alice","age":25,"city":"NewYork"}
-                        new BoundaryPattern("{", "}", false),
-                        // ["Alice", "Bob"]
-                        new BoundaryPattern("[", "]", false)};
-        for (BoundaryPattern pattern : patterns) {
-            String extracted =
-                    extractString(aiMessage, pattern.left, pattern.right, pattern.exclusionFlag);
-            if (extracted == null) {
-                continue;
-            }
-            // 判断是否能解析为Object或者Array
-            try {
-                JSON.parseObject(extracted);
-                return extracted;
-            } catch (JSONException ignored) {
-                // ignored
-            }
-            try {
-                JSON.parseArray(extracted);
-                return extracted;
-            } catch (JSONException ignored) {
-                // ignored
-            }
-        }
-        throw new JSONException("json extract failed");
     }
 }

--- a/headless/server/src/main/java/com/tencent/supersonic/headless/server/utils/ChatWorkflowEngine.java
+++ b/headless/server/src/main/java/com/tencent/supersonic/headless/server/utils/ChatWorkflowEngine.java
@@ -174,13 +174,15 @@ public class ChatWorkflowEngine {
             for (SemanticQuery semanticQuery : candidateQueries) {
                 for (SemanticCorrector corrector : semanticCorrectors) {
                     if (corrector instanceof LLMPhysicalSqlCorrector) {
-                        corrector.correct(queryCtx, semanticQuery.getParseInfo());
-                        // 如果物理SQL被修正了，更新querySQL为修正后的版本
                         SemanticParseInfo parseInfo = semanticQuery.getParseInfo();
-                        if (StringUtils.isNotBlank(parseInfo.getSqlInfo().getCorrectedQuerySQL())) {
-                            parseInfo.getSqlInfo().setQuerySQL(parseInfo.getSqlInfo().getCorrectedQuerySQL());
-                            log.info("Physical SQL corrected and updated querySQL: {}", 
-                                    parseInfo.getSqlInfo().getQuerySQL());
+                        String originalSQL = parseInfo.getSqlInfo().getQuerySQL();
+                        corrector.correct(queryCtx, parseInfo);
+                        String optimizedSQL = parseInfo.getSqlInfo().getCorrectedQuerySQL();
+                        if (StringUtils.isNotBlank(optimizedSQL)) {
+                            parseInfo.getSqlInfo().setCorrectedQuerySQL(originalSQL);
+                            parseInfo.getSqlInfo().setQuerySQL(optimizedSQL);
+                            log.info("Corrected Physical SQL: {}", 
+                                    StringUtils.normalizeSpace(optimizedSQL));
                         }
                         break;
                     }

--- a/webapp/packages/chat-sdk/src/components/ChatItem/SqlItem.tsx
+++ b/webapp/packages/chat-sdk/src/components/ChatItem/SqlItem.tsx
@@ -118,7 +118,7 @@ ${format(sqlInfo.correctedS2SQL)}
 
   const getCorrectedQuerySQLText = () => {
     return `
-物理SQL修正
+物理SQL修正前
 
 ${format(sqlInfo.correctedQuerySQL || '')}
 `;
@@ -240,7 +240,7 @@ ${executeErrorMsg}
                 setSqlType(sqlType === 'correctedQuerySQL' ? '' : 'correctedQuerySQL');
               }}
             >
-              物理SQL修正
+              物理SQL修正前
             </div>
           )}
           {sqlInfo.querySQL && (

--- a/webapp/packages/supersonic-fe/src/pages/SemanticModel/utils.tsx
+++ b/webapp/packages/supersonic-fe/src/pages/SemanticModel/utils.tsx
@@ -1,4 +1,3 @@
-import type { API } from '@/services/API';
 import { ISemantic } from './data';
 import type { DataNode } from 'antd/lib/tree';
 import { Form, Input, InputNumber, Switch, Select, Slider } from 'antd';
@@ -209,14 +208,11 @@ export const genneratorFormItemList = (itemList: ConfigParametersItem[]) => {
         return itemList;
       case 'list': {
         const { candidateValues = [] } = item;
-        const options = candidateValues.map((item: string | { label: string; value: string }) => {
-          if (isString(item)) {
-            return { label: item, value: item };
+        const options = candidateValues.map((optionItem: any) => {
+          if (isString(optionItem)) {
+            return { label: optionItem, value: optionItem };
           }
-          if (item?.label) {
-            return item;
-          }
-          return { label: item, value: item };
+          return { label: optionItem.label, value: optionItem.value };
         });
         defaultItem = (
           <Select style={{ width: '100%' }} options={options} placeholder={placeholder} />


### PR DESCRIPTION
## Description

三次commit分别对应如下：
1. 修复前次pr中的一个瑕疵#2306。修正物理校正SQL和最终执行SQL显示一致的问题，现改为分别显示为物理校正前，和最终执行SQL
2. 智能识别只能通过写死的逻辑，在线调用默认gpt-4o-mini。修改为可以调用大模型管理界面所有大语言模型，在线调用默认gpt-4o-mini作为兜底，方便只在本地调取本地模型或其他在线模型，同时支持自定义prompt #2312 
3. 修复智能识别得到的别名，无法在问答中被转换的问题 #2021 #1814 #2199 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## How Has This Been Tested?

- [x] 已在本地验证前端显示
- [x] 已验证openAI协议下，gpt-4o-mini和glm-4-flash模型的提示词，指标智能识别和维度智能识别都可以正常识别填充，并且落表，最终界面如图 #2312 
- [x] 我所使用的别名修改后，可以正常的在问答对话流程中被识别为相应的Schema，并且后续相应物理转换过程也匹配到对应SQL实际列


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules