### PR TITLE
(fix)(headless-server)sqlExecuteReq.getSql() 兼容sql前后有换行符CASE,导致sql语句结…

### DIFF
--- a/headless/api/src/main/java/com/tencent/supersonic/headless/api/pojo/request/SqlExecuteReq.java
+++ b/headless/api/src/main/java/com/tencent/supersonic/headless/api/pojo/request/SqlExecuteReq.java
@@ -23,9 +23,11 @@ public class SqlExecuteReq {
     private Integer limit = 1000;
 
     public String getSql() {
-        if (StringUtils.isNotBlank(sql) && sql.endsWith(";")) {
-            sql = sql.substring(0, sql.length() - 1);
+        if(StringUtils.isNotBlank(sql)){
+            sql=sql.replaceAll("^[\\n]+|[\\n]+$", "");
+            sql=StringUtils.removeEnd(sql,";");
         }
+
         return String.format(LIMIT_WRAPPER, sql, limit);
     }
 }


### PR DESCRIPTION
## Description
fixed bug [Bug] sqlExecuteReq.getSql() 兼容sql前后有换行符,导致sql语句结尾";"无法被正确删除CASE

Please include a summary of the change and which issue is fixed. Also include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional information

Any additional information, configuration or data that might be necessary to reproduce the issue.