### PR TITLE
(fix)(headless-server)语意建模-X模型-维度管理-维度搜索带key查询时，返回的维度结果范围超出了X模型范围

### DIFF
--- a/headless/server/src/main/java/com/tencent/supersonic/headless/server/persistence/repository/impl/DimensionRepositoryImpl.java
+++ b/headless/server/src/main/java/com/tencent/supersonic/headless/server/persistence/repository/impl/DimensionRepositoryImpl.java
@@ -83,10 +83,10 @@ public class DimensionRepositoryImpl implements DimensionRepository {
         }
         if (StringUtils.isNotBlank(dimensionFilter.getKey())) {
             String key = dimensionFilter.getKey();
-            queryWrapper.lambda().like(DimensionDO::getName, key).or()
+            queryWrapper.and(qw->qw.lambda().like(DimensionDO::getName, key).or()
                     .like(DimensionDO::getBizName, key).or().like(DimensionDO::getDescription, key)
                     .or().like(DimensionDO::getAlias, key).or()
-                    .like(DimensionDO::getCreatedBy, key);
+                    .like(DimensionDO::getCreatedBy, key));
         }
 
         return dimensionDOMapper.selectList(queryWrapper);


### PR DESCRIPTION
## Description

fixed bug [Bug] 语意建模-X模型-维度管理-维度搜索带key查询时，返回的维度结果范围超出了X模型范围(#2326) fixed #2326
Please include a summary of the change and which issue is fixed. Also include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional information

Any additional information, configuration or data that might be necessary to reproduce the issue.