### PR TITLE
(fix)(headless-chat)  修复FileHandlerImpl.convert2Resp() 维度值数据行首字符为空格时异常

### DIFF
--- a/headless/chat/src/main/java/com/tencent/supersonic/headless/chat/knowledge/file/FileHandlerImpl.java
+++ b/headless/chat/src/main/java/com/tencent/supersonic/headless/chat/knowledge/file/FileHandlerImpl.java
@@ -175,6 +175,7 @@ public class FileHandlerImpl implements FileHandler {
     private DictValueResp convert2Resp(String lineStr) {
         DictValueResp dictValueResp = new DictValueResp();
         if (StringUtils.isNotEmpty(lineStr)) {
+            lineStr=StringUtils.stripStart(lineStr,null);
             String[] itemArray = lineStr.split("\\s+");
             if (Objects.nonNull(itemArray) && itemArray.length >= 3) {
                 dictValueResp.setValue(itemArray[0].replace("#", " "));


### PR DESCRIPTION
# Pull Request Template

## Description
> 修复FileHandlerImpl.convert2Resp()导入维度值数据， 纬度值数据行首字符为空格时异常。(#2335) fixed #2335

Please include a summary of the change and which issue is fixed. Also include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional information

Any additional information, configuration or data that might be necessary to reproduce the issue.