### PR TITLE
Remove IsTranslated identifier

### DIFF
--- a/headless/server/src/main/java/com/tencent/supersonic/headless/server/facade/service/impl/S2SemanticLayerService.java
+++ b/headless/server/src/main/java/com/tencent/supersonic/headless/server/facade/service/impl/S2SemanticLayerService.java
@@ -294,7 +294,6 @@ public class S2SemanticLayerService implements SemanticLayerService {
         if (Objects.nonNull(queryStatement) && Objects.nonNull(semanticQueryReq.getSqlInfo())
                 && StringUtils.isNotBlank(semanticQueryReq.getSqlInfo().getQuerySQL())) {
             queryStatement.setSql(semanticQueryReq.getSqlInfo().getQuerySQL());
-            queryStatement.setIsTranslated(true);
         }
         if (queryStatement != null) {
             queryStatement.setUser(user);


### PR DESCRIPTION
现有代码会设置 isTranslated = true标志。这导致后续流程中跳过必要的翻译转换步骤，造成查询结果无法正确更新。
<img width="1920" height="921" alt="image" src="https://github.com/user-attachments/assets/a92f34f1-3184-4b45-882e-391bc329832b" />
<img width="1920" height="921" alt="image" src="https://github.com/user-attachments/assets/7ed1898d-3d83-4e6b-a6c5-b2734d892e05" />
