### PR TITLE
(fix)(headless) correct SQL when WHERE condition contains only column without function

### DIFF
--- a/common/src/main/java/com/tencent/supersonic/common/jsqlparser/SqlAddHelper.java
+++ b/common/src/main/java/com/tencent/supersonic/common/jsqlparser/SqlAddHelper.java
@@ -309,7 +309,7 @@ public class SqlAddHelper {
         }
     }
 
-    public static String addHaving(String sql, Set<String> fieldNames) {
+    public static String addHaving(String sql, Map<String, String> fieldNames) {
         Select selectStatement = SqlSelectHelper.getSelect(sql);
 
         if (!(selectStatement instanceof PlainSelect)) {

--- a/common/src/test/java/com/tencent/supersonic/common/jsqlparser/SqlAddHelperTest.java
+++ b/common/src/test/java/com/tencent/supersonic/common/jsqlparser/SqlAddHelperTest.java
@@ -338,8 +338,8 @@ class SqlAddHelperTest {
         List<String> groupByFields = new ArrayList<>();
         groupByFields.add("department");
 
-        Set<String> fieldNames = new HashSet<>();
-        fieldNames.add("pv");
+        Map<String, String> fieldNames = new HashMap<>();
+        fieldNames.put("pv", "sum");
 
         String replaceSql = SqlAddHelper.addHaving(sql, fieldNames);
 
@@ -354,6 +354,14 @@ class SqlAddHelperTest {
 
         Assert.assertEquals("SELECT department, sum(pv) FROM t_1 WHERE sys_imp_date = '2023-09-11' "
                 + "GROUP BY department HAVING sum(pv) > 2000 ORDER BY sum(pv) DESC LIMIT 10",
+                replaceSql);
+
+        sql = "SELECT 数据日期,访问用户数 FROM 超音数数据集 WHERE 访问次数 > 10 GROUP BY 数据日期";
+
+        fieldNames.put("访问次数", "sum");
+        replaceSql = SqlAddHelper.addHaving(sql, fieldNames);
+
+        Assert.assertEquals("SELECT 数据日期, 访问用户数 FROM 超音数数据集 GROUP BY 数据日期 HAVING 访问次数 > 10",
                 replaceSql);
     }
 

--- a/headless/chat/src/main/java/com/tencent/supersonic/headless/chat/corrector/HavingCorrector.java
+++ b/headless/chat/src/main/java/com/tencent/supersonic/headless/chat/corrector/HavingCorrector.java
@@ -3,6 +3,7 @@ package com.tencent.supersonic.headless.chat.corrector;
 import com.tencent.supersonic.common.jsqlparser.SqlAddHelper;
 import com.tencent.supersonic.common.jsqlparser.SqlSelectFunctionHelper;
 import com.tencent.supersonic.common.jsqlparser.SqlSelectHelper;
+import com.tencent.supersonic.headless.api.pojo.SchemaElement;
 import com.tencent.supersonic.headless.api.pojo.SemanticParseInfo;
 import com.tencent.supersonic.headless.api.pojo.SemanticSchema;
 import com.tencent.supersonic.headless.chat.ChatQueryContext;
@@ -11,7 +12,8 @@ import net.sf.jsqlparser.expression.Expression;
 import org.springframework.util.CollectionUtils;
 
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /** Perform SQL corrections on the "Having" section in S2SQL. */
@@ -29,8 +31,9 @@ public class HavingCorrector extends BaseSemanticCorrector {
 
         SemanticSchema semanticSchema = chatQueryContext.getSemanticSchema();
 
-        Set<String> metrics = semanticSchema.getMetrics(dataSet).stream()
-                .map(schemaElement -> schemaElement.getName()).collect(Collectors.toSet());
+        Map<String, String> metrics = semanticSchema.getMetrics(dataSet).stream()
+                .collect(Collectors.toMap(SchemaElement::getName,
+                        e -> Optional.ofNullable(e.getDefaultAgg()).orElse("")));
 
         if (CollectionUtils.isEmpty(metrics)) {
             return;


### PR DESCRIPTION
# Pull Request Template

## Description

我使用qwen3的时候会生成类似`SELECT 数据日期,访问用户数 FROM 超音数数据集 WHERE 访问次数 > 10 GROUP BY 数据日期`sql，不能把where纠正为having，现在添加列聚合类型判断来纠正sql

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional information

Any additional information, configuration or data that might be necessary to reproduce the issue.