### PR TITLE
(fix)(handless)Fix parse date number error

### DIFF
--- a/headless/chat/src/main/java/com/tencent/supersonic/headless/chat/parser/rule/TimeRangeParser.java
+++ b/headless/chat/src/main/java/com/tencent/supersonic/headless/chat/parser/rule/TimeRangeParser.java
@@ -32,7 +32,7 @@ public class TimeRangeParser implements SemanticParser {
 
     private static final Pattern RECENT_PATTERN_CN = Pattern.compile(
             ".*(?<periodStr>(近|过去)((?<enNum>\\d+)|(?<zhNum>[一二三四五六七八九十百千万亿]+))个?(?<zhPeriod>[天周月年])).*");
-    private static final Pattern DATE_PATTERN_NUMBER = Pattern.compile("(\\d{8})");
+    private static final Pattern DATE_PATTERN_NUMBER = Pattern.compile("\\b(\\d{8})\\b");
     private static final DateFormat DATE_FORMAT_NUMBER = new SimpleDateFormat("yyyyMMdd");
     private static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
 

--- a/headless/server/src/main/java/com/tencent/supersonic/headless/server/service/impl/RetrieveServiceImpl.java
+++ b/headless/server/src/main/java/com/tencent/supersonic/headless/server/service/impl/RetrieveServiceImpl.java
@@ -1,6 +1,5 @@
 package com.tencent.supersonic.headless.server.service.impl;
 
-import com.google.common.collect.Lists;
 import com.tencent.supersonic.common.pojo.User;
 import com.tencent.supersonic.common.pojo.enums.DictWordType;
 import com.tencent.supersonic.headless.api.pojo.SchemaElement;


### PR DESCRIPTION
# Pull Request Template

## Description
When query is that “用户ID为111111118888888的订单数”. TimeRangeParser may produce unexpected results when parsing date numbers, and you will get an **too long date list**. This has a huge negative impact on mapping performance.
​​
![20250821-152338](https://github.com/user-attachments/assets/a981148d-f0d8-47af-84cd-4174d7c853ea)

So I modified the regex, add word boundary，like `\\b(\\d{8})\\b`
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional information

Any additional information, configuration or data that might be necessary to reproduce the issue.