### PR TITLE
(fix)(headless)Add dimension datatype in prompt

### DIFF
--- a/common/src/main/java/com/tencent/supersonic/common/pojo/DimensionConstants.java
+++ b/common/src/main/java/com/tencent/supersonic/common/pojo/DimensionConstants.java
@@ -5,4 +5,6 @@ public class DimensionConstants {
     public static final String DIMENSION_TIME_FORMAT = "time_format";
 
     public static final String DIMENSION_TYPE = "dimension_type";
+
+    public static final String DIMENSION_DATA_TYPE = "dimension_data_type";
 }

--- a/headless/chat/src/main/java/com/tencent/supersonic/headless/chat/parser/llm/PromptHelper.java
+++ b/headless/chat/src/main/java/com/tencent/supersonic/headless/chat/parser/llm/PromptHelper.java
@@ -17,6 +17,7 @@ import org.springframework.util.CollectionUtils;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static com.tencent.supersonic.common.pojo.DimensionConstants.*;
 import static com.tencent.supersonic.headless.chat.parser.ParserConfig.*;
 
 @Component
@@ -141,6 +142,9 @@ public class PromptHelper {
                 StringBuilder alias = new StringBuilder();
                 dimension.getAlias().forEach(a -> alias.append(a).append(";"));
                 dimensionStr.append(" ALIAS '").append(alias).append("'");
+            }
+            if (Objects.nonNull(dimension.getExtInfo().get(DIMENSION_DATA_TYPE))) {
+                dimensionStr.append(" DATATYPE '").append(dimension.getExtInfo().get(DIMENSION_DATA_TYPE)).append("'");
             }
             if (StringUtils.isNotEmpty(dimension.getTimeFormat())) {
                 dimensionStr.append(" FORMAT '").append(dimension.getTimeFormat()).append("'");


### PR DESCRIPTION
# Pull Request Template

## Description
When my question is "用户ID为12345678的订单数"，then LLM parsed result is `where 用户ID = 12345678`.
But in physical database, user_id is of string type. so, the query result is empty.

When my question is "用户**UID**为12345678的订单数"，then LLM parsed result is `where 用户ID = '12345678'`.
This time the query results are correct. 

There is no datatype information in the prompt, LLM can only judge it by the question and the field name in the mapping result.
so I think it is necessary to add datatype. But I am not sure whether the `data_type` in `s2_dimension` is available(looks like it's not used).So I code in a more compatible way. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional information
**PS: Should the default few-shot also be added with datatype?**
