### PR TITLE
deps: bump nltk to 3.10.3 in evaluation

### DIFF
--- a/evaluation/requirements.txt
+++ b/evaluation/requirements.txt
@@ -2,5 +2,5 @@ pysqlite3==0.5.2
 PyJWT==2.8.0
 PyYAML==6.0.1
 sqlparse==0.4.4
-nltk==3.8.1
+nltk==3.10.3
 


### PR DESCRIPTION
Updates `nltk` to address the advisories listed below.

Evidence:
- `evaluation/requirements.txt` pinned `nltk@3.8.1`
- `osv-scanner` reported PYSEC-2026-96, PYSEC-2026-97, PYSEC-2026-98, PYSEC-2026-99, PYSEC-2026-2078, PYSEC-2026-2085, PYSEC-2026-2235, PYSEC-2026-2236, PYSEC-2026-2237, PYSEC-2026-3581, PYSEC-2026-3582, PYSEC-2026-3583, PYSEC-2026-3584, PYSEC-2026-3657, PYSEC-2024-167 and their linked GHSAs for `nltk@3.8.1`
- updated version: `3.10.3`

Validation:
- `osv-scanner --lockfile=evaluation/requirements.txt` no longer reports any advisory for `nltk` after the update
- `pip install nltk==3.10.3` and `import nltk` pass in a clean venv
- the evaluation suite needs a running service environment, so it was not executed locally

Note: `osv-scanner` still reports separate advisories for other packages in `evaluation/requirements.txt` (pyjwt 2.8.0 and others). This patch only clears the nltk advisories.

Scope: dependency/lockfile update only.
