### PR TITLE
feat: Add support for vector search with Qdrant

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -187,6 +187,10 @@
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-qdrant</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-embeddings-bge-small-zh</artifactId>
         </dependency>
         <dependency>

--- a/common/src/main/java/com/tencent/supersonic/common/config/EmbeddingStoreParameterConfig.java
+++ b/common/src/main/java/com/tencent/supersonic/common/config/EmbeddingStoreParameterConfig.java
@@ -19,7 +19,7 @@ public class EmbeddingStoreParameterConfig extends ParameterConfig {
 
     public static final Parameter EMBEDDING_STORE_PROVIDER =
             new Parameter("s2.embedding.store.provider", EmbeddingStoreType.IN_MEMORY.name(),
-                    "向量库类型", "目前支持四种类型：IN_MEMORY、MILVUS、CHROMA、PGVECTOR、OPENSEARCH", "list",
+                    "向量库类型", "目前支持六种类型：IN_MEMORY、MILVUS、CHROMA、PGVECTOR、OPENSEARCH、QDRANT", "list",
                     MODULE_NAME, getCandidateValues());
 
     public static final Parameter EMBEDDING_STORE_BASE_URL =
@@ -48,6 +48,10 @@ public class EmbeddingStoreParameterConfig extends ParameterConfig {
     public static final Parameter EMBEDDING_STORE_POST = new Parameter("s2.embedding.store.port",
             "", "端口", "", "number", MODULE_NAME, null, getPortDependency());
 
+    public static final Parameter EMBEDDING_STORE_USE_TLS =
+            new Parameter("s2.embedding.store.useTls", "false", "使用TLS", "", "bool", MODULE_NAME,
+                    null, getUseTlsDependency());
+
     public static final Parameter EMBEDDING_STORE_USER = new Parameter("s2.embedding.store.user",
             "", "用户名", "", "string", MODULE_NAME, null, getUserDependency());
 
@@ -58,8 +62,8 @@ public class EmbeddingStoreParameterConfig extends ParameterConfig {
     @Override
     public List<Parameter> getSysParameters() {
         return Lists.newArrayList(EMBEDDING_STORE_PROVIDER, EMBEDDING_STORE_BASE_URL,
-                EMBEDDING_STORE_POST, EMBEDDING_STORE_USER, EMBEDDING_STORE_PASSWORD,
-                EMBEDDING_STORE_API_KEY, EMBEDDING_STORE_DATABASE_NAME,
+                EMBEDDING_STORE_POST, EMBEDDING_STORE_USE_TLS, EMBEDDING_STORE_USER,
+                EMBEDDING_STORE_PASSWORD, EMBEDDING_STORE_API_KEY, EMBEDDING_STORE_DATABASE_NAME,
                 EMBEDDING_STORE_PERSIST_PATH, EMBEDDING_STORE_TIMEOUT, EMBEDDING_STORE_DIMENSION);
     }
 
@@ -80,32 +84,38 @@ public class EmbeddingStoreParameterConfig extends ParameterConfig {
         }
         String user = getParameterValue(EMBEDDING_STORE_USER);
         String password = getParameterValue(EMBEDDING_STORE_PASSWORD);
+        Boolean useTls = Boolean.valueOf(getParameterValue(EMBEDDING_STORE_USE_TLS));
         return EmbeddingStoreConfig.builder().provider(provider).baseUrl(baseUrl).apiKey(apiKey)
                 .persistPath(persistPath).databaseName(databaseName).timeOut(Long.valueOf(timeOut))
-                .dimension(dimension).post(port).user(user).password(password).build();
+                .dimension(dimension).post(port).user(user).password(password).useTls(useTls)
+                .build();
     }
 
     private static ArrayList<String> getCandidateValues() {
         return Lists.newArrayList(EmbeddingStoreType.IN_MEMORY.name(),
                 EmbeddingStoreType.MILVUS.name(), EmbeddingStoreType.CHROMA.name(),
-                EmbeddingStoreType.PGVECTOR.name(), EmbeddingStoreType.OPENSEARCH.name());
+                EmbeddingStoreType.PGVECTOR.name(), EmbeddingStoreType.OPENSEARCH.name(),
+                EmbeddingStoreType.QDRANT.name());
     }
 
     private static List<Parameter.Dependency> getBaseUrlDependency() {
         return getDependency(EMBEDDING_STORE_PROVIDER.getName(),
                 Lists.newArrayList(EmbeddingStoreType.MILVUS.name(),
                         EmbeddingStoreType.CHROMA.name(), EmbeddingStoreType.PGVECTOR.name(),
-                        EmbeddingStoreType.OPENSEARCH.name()),
+                        EmbeddingStoreType.OPENSEARCH.name(), EmbeddingStoreType.QDRANT.name()),
                 ImmutableMap.of(EmbeddingStoreType.MILVUS.name(), "http://localhost:19530",
                         EmbeddingStoreType.CHROMA.name(), "http://localhost:8000",
                         EmbeddingStoreType.PGVECTOR.name(), "127.0.0.1",
-                        EmbeddingStoreType.OPENSEARCH.name(), "http://localhost:9200"));
+                        EmbeddingStoreType.OPENSEARCH.name(), "http://localhost:9200",
+                        EmbeddingStoreType.QDRANT.name(), "localhost"));
     }
 
     private static List<Parameter.Dependency> getApiKeyDependency() {
         return getDependency(EMBEDDING_STORE_PROVIDER.getName(),
-                Lists.newArrayList(EmbeddingStoreType.MILVUS.name()),
-                ImmutableMap.of(EmbeddingStoreType.MILVUS.name(), DEMO));
+                Lists.newArrayList(EmbeddingStoreType.MILVUS.name(),
+                        EmbeddingStoreType.QDRANT.name()),
+                ImmutableMap.of(EmbeddingStoreType.MILVUS.name(), DEMO,
+                        EmbeddingStoreType.QDRANT.name(), ""));
     }
 
     private static List<Parameter.Dependency> getPathDependency() {
@@ -117,10 +127,12 @@ public class EmbeddingStoreParameterConfig extends ParameterConfig {
     private static List<Parameter.Dependency> getDimensionDependency() {
         return getDependency(EMBEDDING_STORE_PROVIDER.getName(),
                 Lists.newArrayList(EmbeddingStoreType.MILVUS.name(),
-                        EmbeddingStoreType.PGVECTOR.name(), EmbeddingStoreType.OPENSEARCH.name()),
+                        EmbeddingStoreType.PGVECTOR.name(), EmbeddingStoreType.OPENSEARCH.name(),
+                        EmbeddingStoreType.QDRANT.name()),
                 ImmutableMap.of(EmbeddingStoreType.MILVUS.name(), "384",
                         EmbeddingStoreType.PGVECTOR.name(), "512",
-                        EmbeddingStoreType.OPENSEARCH.name(), "512"));
+                        EmbeddingStoreType.OPENSEARCH.name(), "512",
+                        EmbeddingStoreType.QDRANT.name(), "384"));
     }
 
     private static List<Parameter.Dependency> getDatabaseNameDependency() {
@@ -134,8 +146,16 @@ public class EmbeddingStoreParameterConfig extends ParameterConfig {
 
     private static List<Parameter.Dependency> getPortDependency() {
         return getDependency(EMBEDDING_STORE_PROVIDER.getName(),
-                Lists.newArrayList(EmbeddingStoreType.PGVECTOR.name()),
-                ImmutableMap.of(EmbeddingStoreType.PGVECTOR.name(), "54333"));
+                Lists.newArrayList(EmbeddingStoreType.PGVECTOR.name(),
+                        EmbeddingStoreType.QDRANT.name()),
+                ImmutableMap.of(EmbeddingStoreType.PGVECTOR.name(), "54333",
+                        EmbeddingStoreType.QDRANT.name(), "6334"));
+    }
+
+    private static List<Parameter.Dependency> getUseTlsDependency() {
+        return getDependency(EMBEDDING_STORE_PROVIDER.getName(),
+                Lists.newArrayList(EmbeddingStoreType.QDRANT.name()),
+                ImmutableMap.of(EmbeddingStoreType.QDRANT.name(), "false"));
     }
 
     private static List<Parameter.Dependency> getUserDependency() {

--- a/common/src/main/java/com/tencent/supersonic/common/pojo/EmbeddingStoreConfig.java
+++ b/common/src/main/java/com/tencent/supersonic/common/pojo/EmbeddingStoreConfig.java
@@ -25,4 +25,5 @@ public class EmbeddingStoreConfig implements Serializable {
     private Integer post;
     private String user;
     private String password;
+    private Boolean useTls = false;
 }

--- a/common/src/main/java/dev/langchain4j/qdrant/spring/QdrantEmbeddingStoreFactory.java
+++ b/common/src/main/java/dev/langchain4j/qdrant/spring/QdrantEmbeddingStoreFactory.java
@@ -1,0 +1,22 @@
+package dev.langchain4j.qdrant.spring;
+
+import com.tencent.supersonic.common.pojo.EmbeddingStoreConfig;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.BaseEmbeddingStoreFactory;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.qdrant.QdrantEmbeddingStore;
+
+public class QdrantEmbeddingStoreFactory extends BaseEmbeddingStoreFactory {
+
+    private final EmbeddingStoreConfig config;
+
+    public QdrantEmbeddingStoreFactory(EmbeddingStoreConfig config) {
+        this.config = config;
+    }
+
+    @Override
+    public EmbeddingStore<TextSegment> createEmbeddingStore(String collectionName) {
+        return new QdrantEmbeddingStore(collectionName, config.getBaseUrl(), config.getPost(),
+                Boolean.TRUE.equals(config.getUseTls()), config.getApiKey(), config.getDimension());
+    }
+}

--- a/common/src/main/java/dev/langchain4j/store/embedding/EmbeddingStoreFactoryProvider.java
+++ b/common/src/main/java/dev/langchain4j/store/embedding/EmbeddingStoreFactoryProvider.java
@@ -8,6 +8,7 @@ import dev.langchain4j.inmemory.spring.InMemoryEmbeddingStoreFactory;
 import dev.langchain4j.milvus.spring.MilvusEmbeddingStoreFactory;
 import dev.langchain4j.opensearch.spring.OpenSearchEmbeddingStoreFactory;
 import dev.langchain4j.pgvector.spring.PgvectorEmbeddingStoreFactory;
+import dev.langchain4j.qdrant.spring.QdrantEmbeddingStoreFactory;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Map;
@@ -50,6 +51,10 @@ public class EmbeddingStoreFactoryProvider {
                 .equalsIgnoreCase(embeddingStoreConfig.getProvider())) {
             return factoryMap.computeIfAbsent(embeddingStoreConfig,
                     storeConfig -> new OpenSearchEmbeddingStoreFactory(storeConfig));
+        }
+        if (EmbeddingStoreType.QDRANT.name().equalsIgnoreCase(embeddingStoreConfig.getProvider())) {
+            return factoryMap.computeIfAbsent(embeddingStoreConfig,
+                    storeConfig -> new QdrantEmbeddingStoreFactory(storeConfig));
         }
         throw new RuntimeException("Unsupported EmbeddingStoreFactory provider: "
                 + embeddingStoreConfig.getProvider());

--- a/common/src/main/java/dev/langchain4j/store/embedding/EmbeddingStoreType.java
+++ b/common/src/main/java/dev/langchain4j/store/embedding/EmbeddingStoreType.java
@@ -1,5 +1,5 @@
 package dev.langchain4j.store.embedding;
 
 public enum EmbeddingStoreType {
-    IN_MEMORY, MILVUS, CHROMA, PGVECTOR, OPENSEARCH
+    IN_MEMORY, MILVUS, CHROMA, PGVECTOR, OPENSEARCH, QDRANT
 }

--- a/common/src/main/java/dev/langchain4j/store/embedding/qdrant/QdrantEmbeddingStore.java
+++ b/common/src/main/java/dev/langchain4j/store/embedding/qdrant/QdrantEmbeddingStore.java
@@ -1,0 +1,222 @@
+package dev.langchain4j.store.embedding.qdrant;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.CosineSimilarity;
+import dev.langchain4j.store.embedding.EmbeddingMatch;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import dev.langchain4j.store.embedding.EmbeddingSearchResult;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.RelevanceScore;
+import dev.langchain4j.store.embedding.filter.Filter;
+import io.qdrant.client.PointIdFactory;
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
+import io.qdrant.client.ValueFactory;
+import io.qdrant.client.VectorOutputHelper;
+import io.qdrant.client.VectorsFactory;
+import io.qdrant.client.WithPayloadSelectorFactory;
+import io.qdrant.client.WithVectorsSelectorFactory;
+import io.qdrant.client.grpc.Collections.Distance;
+import io.qdrant.client.grpc.Collections.VectorParams;
+import io.qdrant.client.grpc.JsonWithInt.Value;
+import io.qdrant.client.grpc.Points.DeletePoints;
+import io.qdrant.client.grpc.Points.DenseVector;
+import io.qdrant.client.grpc.Points.PointStruct;
+import io.qdrant.client.grpc.Points.PointsSelector;
+import io.qdrant.client.grpc.Points.ScoredPoint;
+import io.qdrant.client.grpc.Points.SearchPoints;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+
+import static dev.langchain4j.internal.Utils.randomUUID;
+import static java.util.Comparator.comparingDouble;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+
+public class QdrantEmbeddingStore implements EmbeddingStore<TextSegment> {
+
+    private static final String TEXT_FIELD = "text_segment";
+    private static final int DEFAULT_PORT = 6334;
+
+    private final QdrantClient client;
+    private final String collectionName;
+
+    public QdrantEmbeddingStore(String collectionName, String host, Integer port, boolean useTls,
+            String apiKey, Integer dimension) {
+        QdrantGrpcClient.Builder grpcBuilder = QdrantGrpcClient.newBuilder(
+                host == null ? "localhost" : host, port == null ? DEFAULT_PORT : port, useTls);
+        if (apiKey != null) {
+            grpcBuilder.withApiKey(apiKey);
+        }
+        this.client = new QdrantClient(grpcBuilder.build());
+        this.collectionName = collectionName;
+        ensureCollectionExists(dimension);
+    }
+
+    @Override
+    public String add(Embedding embedding) {
+        String id = randomUUID();
+        add(id, embedding);
+        return id;
+    }
+
+    @Override
+    public void add(String id, Embedding embedding) {
+        addInternal(id, embedding, null);
+    }
+
+    @Override
+    public String add(Embedding embedding, TextSegment segment) {
+        String id = randomUUID();
+        addInternal(id, embedding, segment);
+        return id;
+    }
+
+    @Override
+    public List<String> addAll(List<Embedding> embeddings) {
+        List<String> ids = embeddings.stream().map(e -> randomUUID()).collect(toList());
+        addAllInternal(ids, embeddings, null);
+        return ids;
+    }
+
+    @Override
+    public List<String> addAll(List<Embedding> embeddings, List<TextSegment> segments) {
+        List<String> ids = embeddings.stream().map(e -> randomUUID()).collect(toList());
+        addAllInternal(ids, embeddings, segments);
+        return ids;
+    }
+
+    @Override
+    public EmbeddingSearchResult<TextSegment> search(EmbeddingSearchRequest request) {
+        SearchPoints.Builder search = SearchPoints.newBuilder().setCollectionName(collectionName)
+                .addAllVector(request.queryEmbedding().vectorAsList())
+                .setWithVectors(WithVectorsSelectorFactory.enable(true))
+                .setWithPayload(WithPayloadSelectorFactory.enable(true))
+                .setLimit(request.maxResults());
+        if (request.filter() != null) {
+            search.setFilter(QdrantFilterConverter.convert(request.filter()));
+        }
+        List<EmbeddingMatch<TextSegment>> matches = await(client.searchAsync(search.build()))
+                .stream().map(point -> toEmbeddingMatch(point, request.queryEmbedding()))
+                .filter(match -> match.score() >= request.minScore())
+                .sorted(comparingDouble(EmbeddingMatch::score)).collect(toList());
+        Collections.reverse(matches);
+        return new EmbeddingSearchResult<>(matches);
+    }
+
+    @Override
+    public void removeAll(Filter filter) {
+        await(client.deleteAsync(collectionName, QdrantFilterConverter.convert(filter)));
+    }
+
+    @Override
+    public void removeAll() {
+        io.qdrant.client.grpc.Common.Filter emptyFilter =
+                io.qdrant.client.grpc.Common.Filter.newBuilder().build();
+        await(client.deleteAsync(DeletePoints.newBuilder().setCollectionName(collectionName)
+                .setPoints(PointsSelector.newBuilder().setFilter(emptyFilter).build()).build()));
+    }
+
+    private void addInternal(String id, Embedding embedding, TextSegment segment) {
+        addAllInternal(Collections.singletonList(id), Collections.singletonList(embedding),
+                segment == null ? null : Collections.singletonList(segment));
+    }
+
+    private void addAllInternal(List<String> ids, List<Embedding> embeddings,
+            List<TextSegment> segments) {
+        List<PointStruct> points = new ArrayList<>(embeddings.size());
+        for (int i = 0; i < embeddings.size(); i++) {
+            PointStruct.Builder point =
+                    PointStruct.newBuilder().setId(PointIdFactory.id(UUID.fromString(ids.get(i))))
+                            .setVectors(VectorsFactory.vectors(embeddings.get(i).vector()));
+            if (segments != null) {
+                point.putAllPayload(toPayload(segments.get(i)));
+            }
+            points.add(point.build());
+        }
+        await(client.upsertAsync(collectionName, points));
+    }
+
+    private Map<String, Value> toPayload(TextSegment segment) {
+        Map<String, Value> payload = new HashMap<>();
+        segment.metadata().toMap().forEach((key, value) -> payload.put(key, toValue(value)));
+        payload.put(TEXT_FIELD, ValueFactory.value(segment.text()));
+        return payload;
+    }
+
+    private static Value toValue(Object value) {
+        if (value == null) {
+            return ValueFactory.nullValue();
+        }
+        if (value instanceof Float || value instanceof Double) {
+            return ValueFactory.value(((Number) value).doubleValue());
+        }
+        if (value instanceof Number) {
+            return ValueFactory.value(((Number) value).longValue());
+        }
+        return ValueFactory.value(value.toString());
+    }
+
+    private EmbeddingMatch<TextSegment> toEmbeddingMatch(ScoredPoint point,
+            Embedding referenceEmbedding) {
+        Map<String, Value> payload = point.getPayloadMap();
+        Value text = payload.get(TEXT_FIELD);
+        Map<String, Object> metadata =
+                payload.entrySet().stream().filter(entry -> !entry.getKey().equals(TEXT_FIELD))
+                        .collect(toMap(Map.Entry::getKey, entry -> toObject(entry.getValue())));
+        Embedding embedding = Embedding.from(extractVectorData(point));
+        double score = RelevanceScore
+                .fromCosineSimilarity(CosineSimilarity.between(embedding, referenceEmbedding));
+        return new EmbeddingMatch<>(score, point.getId().getUuid(), embedding, text == null ? null
+                : TextSegment.from(text.getStringValue(), new Metadata(metadata)));
+    }
+
+    private static Object toObject(Value value) {
+        switch (value.getKindCase()) {
+            case INTEGER_VALUE:
+                return value.getIntegerValue();
+            case DOUBLE_VALUE:
+                return value.getDoubleValue();
+            case NULL_VALUE:
+                return null;
+            default:
+                return value.getStringValue();
+        }
+    }
+
+    private List<Float> extractVectorData(ScoredPoint point) {
+        DenseVector dense = VectorOutputHelper.getDenseVector(point.getVectors().getVector());
+        return dense == null ? Collections.emptyList() : dense.getDataList();
+    }
+
+    private void ensureCollectionExists(Integer dimension) {
+        if (dimension == null) {
+            return;
+        }
+        try {
+            if (!client.collectionExistsAsync(collectionName).get()) {
+                client.createCollectionAsync(collectionName, VectorParams.newBuilder()
+                        .setSize(dimension).setDistance(Distance.Cosine).build()).get();
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static <T> T await(ListenableFuture<T> future) {
+        try {
+            return future.get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/common/src/main/java/dev/langchain4j/store/embedding/qdrant/QdrantFilterConverter.java
+++ b/common/src/main/java/dev/langchain4j/store/embedding/qdrant/QdrantFilterConverter.java
@@ -1,0 +1,46 @@
+package dev.langchain4j.store.embedding.qdrant;
+
+import dev.langchain4j.store.embedding.filter.Filter;
+import dev.langchain4j.store.embedding.filter.comparison.IsEqualTo;
+import dev.langchain4j.store.embedding.filter.comparison.IsIn;
+import dev.langchain4j.store.embedding.filter.logical.And;
+import dev.langchain4j.store.embedding.filter.logical.Or;
+import io.qdrant.client.ConditionFactory;
+import io.qdrant.client.grpc.Common.Condition;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class QdrantFilterConverter {
+
+    private QdrantFilterConverter() {}
+
+    static io.qdrant.client.grpc.Common.Filter convert(Filter filter) {
+        List<Condition> must = new ArrayList<>();
+        List<Condition> should = new ArrayList<>();
+        if (filter instanceof And) {
+            And and = (And) filter;
+            must.add(ConditionFactory.filter(convert(and.left())));
+            must.add(ConditionFactory.filter(convert(and.right())));
+        } else if (filter instanceof Or) {
+            Or or = (Or) filter;
+            should.add(ConditionFactory.filter(convert(or.left())));
+            should.add(ConditionFactory.filter(convert(or.right())));
+        } else if (filter instanceof IsEqualTo) {
+            IsEqualTo equalTo = (IsEqualTo) filter;
+            must.add(ConditionFactory.matchKeyword(equalTo.key(),
+                    equalTo.comparisonValue().toString()));
+        } else if (filter instanceof IsIn) {
+            IsIn in = (IsIn) filter;
+            List<String> values = new ArrayList<>();
+            for (Object value : in.comparisonValues()) {
+                values.add(value.toString());
+            }
+            must.add(ConditionFactory.matchKeywords(in.key(), values));
+        } else {
+            throw new UnsupportedOperationException("Unsupported filter: " + filter);
+        }
+        return io.qdrant.client.grpc.Common.Filter.newBuilder().addAllMust(must)
+                .addAllShould(should).build();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,9 @@
         <stax2.version>4.2.2</stax2.version>
         <aws-java-sdk.version>1.12.780</aws-java-sdk.version>
         <jgrapht.version>1.5.2</jgrapht.version>
+        <grpc.version>1.83.0</grpc.version>
+        <protobuf.version>3.25.9</protobuf.version>
+        <qdrant.client.version>1.19.0</qdrant.client.version>
     </properties>
 
     <dependencyManagement>
@@ -169,6 +172,11 @@
             </dependency>
             <dependency>
                 <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-qdrant</artifactId>
+                <version>${langchain4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
                 <artifactId>langchain4j-ollama</artifactId>
                 <version>${langchain4j.version}</version>
             </dependency>
@@ -221,6 +229,24 @@
                 <groupId>org.jgrapht</groupId>
                 <artifactId>jgrapht-core</artifactId>
                 <version>${jgrapht.version}</version>
+            </dependency>
+            <!--grpc (align across milvus and qdrant client versions)-->
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-bom</artifactId>
+                <version>${grpc.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.qdrant</groupId>
+                <artifactId>client</artifactId>
+                <version>${qdrant.client.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java</artifactId>
+                <version>${protobuf.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Description

This PR adds support for using Qdrant as a vector search provider in Supersonic.

[Qdrant](https://qdrant.tech/) is an open-source vector search engine built for high-performance and massive scale.

### Testing

I've unit tested this integration against a local Qdrant instance.

### Setup

You can run Qdrant with 

```bash
docker run -p 6333:6333 -p 6334:6334 qdrant/qdrant
```

The dashboard is accessible at http://localhost:6333/dashboard.

The Qdrant Java client uses the gRPC API available at `host=localhost` and `port=6334` ([Ref](https://qdrant.tech/documentation/interfaces/)).